### PR TITLE
Adjust safe validation & allow entering EIP-3770 addresses when adding safe

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
     defaultConfig {
         applicationId "io.gnosis.safe"
         versionCode getInt("APP_VERSION_CODE", 703)
-        versionName getKey("APP_VERSION_NAME", "3.3.0")
+        versionName getKey("APP_VERSION_NAME", "3.3.1")
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         // Infura API key

--- a/app/src/main/java/io/gnosis/safe/di/modules/DatabaseModule.kt
+++ b/app/src/main/java/io/gnosis/safe/di/modules/DatabaseModule.kt
@@ -10,6 +10,7 @@ import io.gnosis.data.db.HeimdallDatabase.Companion.MIGRATION_2_3
 import io.gnosis.data.db.HeimdallDatabase.Companion.MIGRATION_3_4
 import io.gnosis.data.db.HeimdallDatabase.Companion.MIGRATION_4_5
 import io.gnosis.data.db.HeimdallDatabase.Companion.MIGRATION_5_6
+import io.gnosis.data.db.HeimdallDatabase.Companion.MIGRATION_6_7
 import io.gnosis.data.db.daos.ChainDao
 import io.gnosis.data.db.daos.OwnerDao
 import io.gnosis.data.db.daos.SafeDao
@@ -23,7 +24,14 @@ class DatabaseModule {
     @Singleton
     fun provideSafeDatabase(@ApplicationContext context: Context): HeimdallDatabase =
         Room.databaseBuilder(context, HeimdallDatabase::class.java, HeimdallDatabase.DB_NAME)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
+            .addMigrations(
+                MIGRATION_1_2,
+                MIGRATION_2_3,
+                MIGRATION_3_4,
+                MIGRATION_4_5,
+                MIGRATION_5_6,
+                MIGRATION_6_7
+            )
             .build()
 
     @Provides

--- a/app/src/main/java/io/gnosis/safe/helpers/AddressInputHelper.kt
+++ b/app/src/main/java/io/gnosis/safe/helpers/AddressInputHelper.kt
@@ -99,10 +99,12 @@ class AddressInputHelper(
     fun handleResult(requestCode: Int, resultCode: Int, data: Intent?) {
         @Suppress("MoveLambdaOutsideParentheses")
         if (!handleQrCodeActivityResult(requestCode, resultCode, data, {
-                addressCallback(parseEthereumAddress(it) ?: run {
-                    handleError(InvalidAddressException(it), it)
-                    return@handleQrCodeActivityResult
-                })
+                addressCallback(
+                    //FIXME: implement proper support for EIP-3770 addresses
+                    parseEthereumAddress(if (it.contains(":")) it.split(":")[1] else it) ?: run {
+                        handleError(InvalidAddressException(it), it)
+                        return@handleQrCodeActivityResult
+                    })
             })) {
             @Suppress("MoveLambdaOutsideParentheses")
             handleAddressBookResult(requestCode, resultCode, data, {

--- a/app/src/main/java/io/gnosis/safe/helpers/AddressInputHelper.kt
+++ b/app/src/main/java/io/gnosis/safe/helpers/AddressInputHelper.kt
@@ -74,10 +74,16 @@ class AddressInputHelper(
                 }
                 bottomSheetAddressInputPasteTouch.setOnClickListener {
                     val input = clipboard.primaryClip?.getItemAt(0)?.text?.trim()
-                    (input?.let { parseEthereumAddress(it.toString()) }
+                    (input?.toString()?.let {
+                        //FIXME: implement proper support for EIP-3770 addresses
+                        parseEthereumAddress(if (it.contains(":")) it.split(":")[1] else it)
+                    }
                         ?: run {
                             fragment.context?.let {
-                                handleError(InvalidAddressException(fragment.getString(R.string.invalid_ethereum_address)), input.toString())
+                                handleError(
+                                    InvalidAddressException(fragment.getString(R.string.invalid_ethereum_address)),
+                                    input.toString()
+                                )
                             } ?: Timber.e(InvalidAddressException(), "Fragment lost context.")
                             null
                         })?.let { addressCallback(it) }

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -21,6 +21,7 @@ android {
         buildConfigField (javaTypes.STRING, "CHAIN_TEXT_COLOR", asString("#001428"))
         buildConfigField (javaTypes.STRING, "CHAIN_BACKGROUND_COLOR", asString("#E8E7E6"))
         buildConfigField (javaTypes.STRING, "BLOCKCHAIN_NAME", asString("Mainnet"))
+        buildConfigField (javaTypes.STRING, "BLOCKCHAIN_SHORT_NAME", asString("eth"))
         buildConfigField javaTypes.STRING, "BLOCKCHAIN_NET_URL", asString(getKey("BLOCKCHAIN_NET_URL", "https://mainnet.infura.io/v3/"))
         buildConfigField javaTypes.STRING, "BLOCKCHAIN_EXPLORER_URL", asString(getKey("BLOCKCHAIN_NET_URL", "https://etherscan.io/"))
 
@@ -37,6 +38,7 @@ android {
             buildConfigField (javaTypes.STRING, "CHAIN_TEXT_COLOR", asString("#ffffff"))
             buildConfigField (javaTypes.STRING, "CHAIN_BACKGROUND_COLOR", asString("#E8673C"))
             buildConfigField (javaTypes.STRING, "BLOCKCHAIN_NAME", asString("Rinkeby"))
+            buildConfigField (javaTypes.STRING, "BLOCKCHAIN_SHORT_NAME", asString("rin"))
             buildConfigField javaTypes.STRING, "BLOCKCHAIN_NET_URL", asString(getKey("BLOCKCHAIN_NET_URL", "https://rinkeby.infura.io/v3/"))
             buildConfigField javaTypes.STRING, "BLOCKCHAIN_EXPLORER_URL", asString(getKey("BLOCKCHAIN_NET_URL", "https://rinkeby.etherscan.io/"))
         }
@@ -48,6 +50,7 @@ android {
             buildConfigField (javaTypes.STRING, "CHAIN_TEXT_COLOR", asString("#ffffff"))
             buildConfigField (javaTypes.STRING, "CHAIN_BACKGROUND_COLOR", asString("#E8673C"))
             buildConfigField (javaTypes.STRING, "BLOCKCHAIN_NAME", asString("Rinkeby"))
+            buildConfigField (javaTypes.STRING, "BLOCKCHAIN_SHORT_NAME", asString("rin"))
             buildConfigField javaTypes.STRING, "BLOCKCHAIN_NET_URL", asString(getKey("BLOCKCHAIN_NET_URL", "https://rinkeby.infura.io/v3/"))
             buildConfigField javaTypes.STRING, "BLOCKCHAIN_EXPLORER_URL", asString(getKey("BLOCKCHAIN_NET_URL", "https://rinkeby.etherscan.io/"))
         }
@@ -59,6 +62,7 @@ android {
             buildConfigField (javaTypes.STRING, "CHAIN_TEXT_COLOR", asString("#ffffff"))
             buildConfigField (javaTypes.STRING, "CHAIN_BACKGROUND_COLOR", asString("#E8673C"))
             buildConfigField (javaTypes.STRING, "BLOCKCHAIN_NAME", asString("Rinkeby"))
+            buildConfigField (javaTypes.STRING, "BLOCKCHAIN_SHORT_NAME", asString("rin"))
             buildConfigField javaTypes.STRING, "BLOCKCHAIN_NET_URL", asString(getKey("BLOCKCHAIN_NET_URL", "https://rinkeby.infura.io/v3/"))
             buildConfigField javaTypes.STRING, "BLOCKCHAIN_EXPLORER_URL", asString(getKey("BLOCKCHAIN_NET_URL", "https://rinkeby.etherscan.io/"))
         }
@@ -70,6 +74,7 @@ android {
             buildConfigField (javaTypes.STRING, "CHAIN_TEXT_COLOR", asString("#ffffff"))
             buildConfigField (javaTypes.STRING, "CHAIN_BACKGROUND_COLOR", asString("#E8673C"))
             buildConfigField (javaTypes.STRING, "BLOCKCHAIN_NAME", asString("Rinkeby"))
+            buildConfigField (javaTypes.STRING, "BLOCKCHAIN_SHORT_NAME", asString("rin"))
             buildConfigField javaTypes.STRING, "BLOCKCHAIN_NET_URL", asString(getKey("BLOCKCHAIN_NET_URL", "https://rinkeby.infura.io/v3/"))
             buildConfigField javaTypes.STRING, "BLOCKCHAIN_EXPLORER_URL", asString(getKey("BLOCKCHAIN_NET_URL", "https://rinkeby.etherscan.io/"))
 

--- a/data/schemas/io.gnosis.data.db.HeimdallDatabase/7.json
+++ b/data/schemas/io.gnosis.data.db.HeimdallDatabase/7.json
@@ -1,0 +1,233 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "ba4cc669f6cdb23a444e2005ee2225c6",
+    "entities": [
+      {
+        "tableName": "safes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`address` TEXT NOT NULL, `local_name` TEXT NOT NULL, `chain_id` TEXT NOT NULL, `version` TEXT, PRIMARY KEY(`address`, `chain_id`))",
+        "fields": [
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localName",
+            "columnName": "local_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chainId",
+            "columnName": "chain_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "address",
+            "chain_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "owners",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`address` TEXT NOT NULL, `name` TEXT, `type` INTEGER NOT NULL, `private_key` TEXT, `seed_phrase` TEXT, `derivation_path` TEXT, PRIMARY KEY(`address`))",
+        "fields": [
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "privateKey",
+            "columnName": "private_key",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "seedPhrase",
+            "columnName": "seed_phrase",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "keyDerivationPath",
+            "columnName": "derivation_path",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "address"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "chains",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chain_id` TEXT NOT NULL, `chain_name` TEXT NOT NULL, `chain_short_name` TEXT NOT NULL, `text_color` TEXT NOT NULL, `background_color` TEXT NOT NULL, `rpc_uri` TEXT NOT NULL, `rpc_authentication` INTEGER NOT NULL, `block_explorer_address_uri` TEXT NOT NULL, `block_explorer_tx_hash_uri` TEXT NOT NULL, `ens_registry_address` TEXT, PRIMARY KEY(`chain_id`))",
+        "fields": [
+          {
+            "fieldPath": "chainId",
+            "columnName": "chain_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "chain_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "chain_short_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textColor",
+            "columnName": "text_color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundColor",
+            "columnName": "background_color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rpcUri",
+            "columnName": "rpc_uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rpcAuthentication",
+            "columnName": "rpc_authentication",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "blockExplorerTemplateAddress",
+            "columnName": "block_explorer_address_uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "blockExplorerTemplateTxHash",
+            "columnName": "block_explorer_tx_hash_uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ensRegistryAddress",
+            "columnName": "ens_registry_address",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "chain_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "native_currency",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chain_id` TEXT NOT NULL, `name` TEXT NOT NULL, `symbol` TEXT NOT NULL, `decimals` INTEGER NOT NULL, `logo_uri` TEXT NOT NULL, PRIMARY KEY(`chain_id`), FOREIGN KEY(`chain_id`) REFERENCES `chains`(`chain_id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "chainId",
+            "columnName": "chain_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "symbol",
+            "columnName": "symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "decimals",
+            "columnName": "decimals",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoUri",
+            "columnName": "logo_uri",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "chain_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "chains",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "chain_id"
+            ],
+            "referencedColumns": [
+              "chain_id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ba4cc669f6cdb23a444e2005ee2225c6')"
+    ]
+  }
+}

--- a/data/src/main/java/io/gnosis/data/db/HeimdallDatabase.kt
+++ b/data/src/main/java/io/gnosis/data/db/HeimdallDatabase.kt
@@ -39,7 +39,7 @@ abstract class HeimdallDatabase : RoomDatabase() {
 
     companion object {
         const val DB_NAME = "safe_db"
-        const val LATEST_DB_VERSION = 6
+        const val LATEST_DB_VERSION = 7
 
         val MIGRATION_1_2 = object : Migration(1, 2) {
             override fun migrate(database: SupportSQLiteDatabase) {
@@ -105,6 +105,14 @@ abstract class HeimdallDatabase : RoomDatabase() {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL(
                     """ALTER TABLE `${Owner.TABLE_NAME}` ADD COLUMN `${Owner.COL_KEY_DERIVATION_PATH}` TEXT"""
+                )
+            }
+        }
+
+        val MIGRATION_6_7 = object : Migration(6, 7) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    """ALTER TABLE `${Chain.TABLE_NAME}` ADD COLUMN `${Chain.COL_CHAIN_SHORT_NAME}` TEXT NOT NULL DEFAULT ''"""
                 )
             }
         }

--- a/data/src/main/java/io/gnosis/data/models/Chain.kt
+++ b/data/src/main/java/io/gnosis/data/models/Chain.kt
@@ -15,6 +15,9 @@ data class Chain(
     @ColumnInfo(name = COL_CHAIN_NAME)
     val name: String,
 
+    @ColumnInfo(name = COL_CHAIN_SHORT_NAME)
+    val shortName: String,
+
     @ColumnInfo(name = COL_TEXT_COLOR)
     val textColor: String,
 
@@ -93,6 +96,7 @@ data class Chain(
         const val TABLE_NAME = "chains"
 
         const val COL_CHAIN_NAME = "chain_name"
+        const val COL_CHAIN_SHORT_NAME = "chain_short_name"
         const val COL_CHAIN_ID = "chain_id"
         const val COL_BACKGROUND_COLOR = "background_color"
         const val COL_RPC_URI = "rpc_uri"
@@ -108,6 +112,7 @@ data class Chain(
         val DEFAULT_CHAIN =  Chain(
             BuildConfig.CHAIN_ID.toBigInteger(),
             BuildConfig.BLOCKCHAIN_NAME,
+            BuildConfig.BLOCKCHAIN_SHORT_NAME,
             BuildConfig.CHAIN_TEXT_COLOR,
             BuildConfig.CHAIN_BACKGROUND_COLOR,
             BuildConfig.BLOCKCHAIN_EXPLORER_URL,

--- a/data/src/main/java/io/gnosis/data/models/ChainInfo.kt
+++ b/data/src/main/java/io/gnosis/data/models/ChainInfo.kt
@@ -10,6 +10,7 @@ import java.math.BigInteger
 data class ChainInfo(
     @Json(name = "chainId") @field:DecimalNumber val chainId: BigInteger,
     @Json(name = "chainName") val chainName: String,
+    @Json(name = "shortName") val shortName: String,
     @Json(name = "ensRegistryAddress") val ensRegistryAddress: String?,
     @Json(name = "rpcUri") val rpcUri: RpcUri,
     @Json(name = "blockExplorerUriTemplate") val blockExplorerTemplate: BlockExplorerTemplate,
@@ -19,7 +20,7 @@ data class ChainInfo(
 ) {
 
     fun toChain(): Chain {
-        return Chain(chainId, chainName, theme.textColor, theme.backgroundColor, rpcUri.value, rpcUri.authentication, blockExplorerTemplate.address, blockExplorerTemplate.txHash, ensRegistryAddress).apply {
+        return Chain(chainId, chainName, shortName, theme.textColor, theme.backgroundColor, rpcUri.value, rpcUri.authentication, blockExplorerTemplate.address, blockExplorerTemplate.txHash, ensRegistryAddress).apply {
             currency = nativeCurrency.toCurrency(chainId)
         }
     }

--- a/data/src/main/java/io/gnosis/data/repositories/SafeRepository.kt
+++ b/data/src/main/java/io/gnosis/data/repositories/SafeRepository.kt
@@ -143,7 +143,7 @@ class SafeRepository(
         }
 
         fun isSupportedVersion(version: SemVer?): Boolean {
-            return version != null && version >= SemVer(1, 0, 0) && version <= SemVer(1, 3, 0)
+            return version != null && version >= SemVer(1, 0, 0)
         }
 
         const val METHOD_SET_FALLBACK_HANDLER = "setFallbackHandler"

--- a/data/src/main/java/io/gnosis/data/utils/SemVer.kt
+++ b/data/src/main/java/io/gnosis/data/utils/SemVer.kt
@@ -4,14 +4,16 @@ data class SemVer(
     val major: Int = 0,
     val minor: Int = 0,
     val patch: Int = 0,
-    val preRelease: String? = null
+    val preRelease: String? = null,
+    val buildMetadata: String? = null
 ) : Comparable<SemVer> {
 
     init {
         require(major >= 0) { "Major version must be a positive number" }
         require(minor >= 0) { "Minor version must be a positive number" }
         require(patch >= 0) { "Patch version must be a positive number" }
-        if (preRelease != null) require(preRelease.matches(Regex("""(0|[1-9]\d*(?:rc)?-)?([A-z\_]+)*"""))) { "Pre-release version is not valid" }
+        if (preRelease != null) require(preRelease.matches(Regex(REGEX_PRE_RELEASE))) { "Pre-release version is not valid" }
+        if (buildMetadata != null) require(buildMetadata.matches(Regex(REGEX_BUILD_META))) { "Build metadata is not valid" }
     }
 
     fun isInside(rangesList: String, ignoreExtensions: Boolean = false): Boolean {
@@ -62,8 +64,9 @@ data class SemVer(
 
     companion object {
 
+        private const val REGEX_BUILD_META = """([0-9A-Za-z-])*"""
         private const val REGEX_PRE_RELEASE = """(0|[1-9]\d*(?:rc)?-)?([A-z\_]+)*"""
-        private const val REGEX_SEM_VER = "(0|[1-9]\\d*)?(?:\\.)?(0|[1-9]\\d*)?(?:\\.)?(0|[1-9]\\d*)?(?:-$REGEX_PRE_RELEASE)?"
+        private const val REGEX_SEM_VER = "(0|[1-9]\\d*)?(?:\\.)?(0|[1-9]\\d*)?(?:\\.)?(0|[1-9]\\d*)?(-$REGEX_PRE_RELEASE)?(\\+$REGEX_BUILD_META)?"
         private const val REGEX_SEM_VER_RANGE = "(${REGEX_SEM_VER})(?:\\.\\.\\.)?(?:(${REGEX_SEM_VER}))?"
 
         fun parse(version: String, ignoreExtensions: Boolean = false): SemVer {
@@ -73,7 +76,8 @@ data class SemVer(
                 major = if (result.groupValues[1].isEmpty()) 0 else result.groupValues[1].toInt(),
                 minor = if (result.groupValues[2].isEmpty()) 0 else result.groupValues[2].toInt(),
                 patch = if (result.groupValues[3].isEmpty()) 0 else result.groupValues[3].toInt(),
-                preRelease = if (ignoreExtensions || result.groupValues[5].isEmpty()) null else "${result.groupValues[4]}${result.groupValues[5]}"
+                preRelease = if (ignoreExtensions || result.groupValues[4].isEmpty()) null else "${result.groupValues[4].substring(1)}",
+                buildMetadata = if (ignoreExtensions || result.groupValues[7].isEmpty()) null else "${result.groupValues[7].substring(1)}"
             )
         }
 
@@ -81,8 +85,8 @@ data class SemVer(
             val pattern = Regex(REGEX_SEM_VER_RANGE)
             val result = pattern.matchEntire(range.trim()) ?: throw IllegalArgumentException("Invalid range version string [$range]")
             return when {
-                result.groupValues[7].isEmpty() -> Pair(parse(result.groupValues[1], ignoreExtensions), null)
-                else -> Pair(parse(result.groupValues[1], ignoreExtensions), parse(result.groupValues[7], ignoreExtensions))
+                result.groupValues[10].isEmpty() -> Pair(parse(result.groupValues[1], ignoreExtensions), null)
+                else -> Pair(parse(result.groupValues[1], ignoreExtensions), parse(result.groupValues[10], ignoreExtensions))
             }
         }
     }

--- a/data/src/test/java/io/gnosis/data/repositories/ChainInfoRepositoryTest.kt
+++ b/data/src/test/java/io/gnosis/data/repositories/ChainInfoRepositoryTest.kt
@@ -23,20 +23,38 @@ class ChainInfoRepositoryTest {
     private val chainInfoRepository = ChainInfoRepository(chainDao, gatewayApi)
 
     private val rinkebyChainInfo = ChainInfo(
-        Chain.ID_RINKEBY, "Rinkeby", null, RpcUri(RpcAuthentication.API_KEY_PATH, ""), BlockExplorerTemplate("", ""),
-        NativeCurrency("", "", 18, ""), "",
+        Chain.ID_RINKEBY,
+        "Rinkeby",
+        "rin",
+        null,
+        RpcUri(RpcAuthentication.API_KEY_PATH, ""),
+        BlockExplorerTemplate("", ""),
+        NativeCurrency("", "", 18, ""),
+        "",
         ChainTheme("", "")
     )
     private val pagedResult: List<ChainInfo> = listOf(
         ChainInfo(
-            Chain.ID_MAINNET, "Mainnet", null, RpcUri(RpcAuthentication.API_KEY_PATH, ""), BlockExplorerTemplate("", ""),
-            NativeCurrency("", "", 18, ""), "",
+            Chain.ID_MAINNET,
+            "Mainnet",
+            "eth",
+            null,
+            RpcUri(RpcAuthentication.API_KEY_PATH, ""),
+            BlockExplorerTemplate("", ""),
+            NativeCurrency("", "", 18, ""),
+            "",
             ChainTheme("", "")
         ),
         rinkebyChainInfo,
         ChainInfo(
-            BigInteger.valueOf(137), "Matic", null, RpcUri(RpcAuthentication.API_KEY_PATH, ""), BlockExplorerTemplate("", ""),
-            NativeCurrency("", "", 18, ""), "",
+            BigInteger.valueOf(137),
+            "Matic",
+            "matic",
+            null,
+            RpcUri(RpcAuthentication.API_KEY_PATH, ""),
+            BlockExplorerTemplate("", ""),
+            NativeCurrency("", "", 18, ""),
+            "",
             ChainTheme("", "")
         )
     )
@@ -63,6 +81,21 @@ class ChainInfoRepositoryTest {
 
         chainInfoRepository.updateChainInfo(pagedResult, safes)
 
-        coVerify(exactly = 1) { chainDao.save(Chain(Chain.ID_RINKEBY, "Rinkeby", "", "", "", RpcAuthentication.API_KEY_PATH, "", "", null)) }
+        coVerify(exactly = 1) {
+            chainDao.save(
+                Chain(
+                    Chain.ID_RINKEBY,
+                    "Rinkeby",
+                    "rin",
+                    "",
+                    "",
+                    "",
+                    RpcAuthentication.API_KEY_PATH,
+                    "",
+                    "",
+                    null
+                )
+            )
+        }
     }
 }

--- a/data/src/test/java/io/gnosis/data/repositories/UnstoppableRepositoryTest.kt
+++ b/data/src/test/java/io/gnosis/data/repositories/UnstoppableRepositoryTest.kt
@@ -48,7 +48,10 @@ class UnstoppableRepositoryTest {
     fun `resolve - (domain) should fail`() = runBlocking {
         coEvery {
             resolutionLib.getAddress(FAIL_DOMAIN, "eth")
-        } throws NamingServiceException(NSExceptionCode.UnregisteredDomain, NSExceptionParams("d", FAIL_DOMAIN))
+        } throws NamingServiceException(
+            NSExceptionCode.UnregisteredDomain,
+            NSExceptionParams("d", FAIL_DOMAIN)
+        )
 
         try {
             repository.resolve(FAIL_DOMAIN, Chain.ID_RINKEBY)
@@ -61,7 +64,20 @@ class UnstoppableRepositoryTest {
     @Test
     fun `canResolve - (1) should succeed for Mainnet`() {
 
-        val result = repository.canResolve(Chain(Chain.ID_MAINNET, "Mainnet", "", "", "", RpcAuthentication.API_KEY_PATH, "", "", null))
+        val result = repository.canResolve(
+            Chain(
+                Chain.ID_MAINNET,
+                "Mainnet",
+                "eth",
+                "",
+                "",
+                "",
+                RpcAuthentication.API_KEY_PATH,
+                "",
+                "",
+                null
+            )
+        )
 
         assertTrue(result)
     }
@@ -70,7 +86,20 @@ class UnstoppableRepositoryTest {
     fun `canResolve - (4) should succeed for Rinkeby`() {
         repository = UnstoppableDomainsRepository()
 
-        val result = repository.canResolve(Chain(Chain.ID_RINKEBY, "Rinkeby", "", "", "", RpcAuthentication.API_KEY_PATH, "", "", null))
+        val result = repository.canResolve(
+            Chain(
+                Chain.ID_RINKEBY,
+                "Rinkeby",
+                "rin",
+                "",
+                "",
+                "",
+                RpcAuthentication.API_KEY_PATH,
+                "",
+                "",
+                null
+            )
+        )
 
         assertTrue(result)
     }
@@ -78,13 +107,27 @@ class UnstoppableRepositoryTest {
     @Test
     fun `canResolve - (17) should fail for unsupported_chain`() {
 
-        val result = repository.canResolve(Chain(BigInteger.valueOf(17), "Unknown", "", "", "", RpcAuthentication.API_KEY_PATH, "", "", null))
+        val result = repository.canResolve(
+            Chain(
+                BigInteger.valueOf(17),
+                "Unknown",
+                "",
+                "",
+                "",
+                "",
+                RpcAuthentication.API_KEY_PATH,
+                "",
+                "",
+                null
+            )
+        )
 
         assertFalse(result)
     }
 
     companion object {
-        private val SUCCESS_ADDR = "0x1C8b9B78e3085866521FE206fa4c1a67F49f153A".asEthereumAddress()!!
+        private val SUCCESS_ADDR =
+            "0x1C8b9B78e3085866521FE206fa4c1a67F49f153A".asEthereumAddress()!!
         private const val SUCCESS_DOMAIN = "udtestdev-creek.crypto"
         private const val FAIL_DOMAIN = "brad.crypto"
 

--- a/data/src/test/java/io/gnosis/data/utils/SemVerTest.kt
+++ b/data/src/test/java/io/gnosis/data/utils/SemVerTest.kt
@@ -18,6 +18,20 @@ class SemVerTest {
     }
 
     @Test
+    fun `parse (versionString with build metadata) should return SemVer`() {
+        val version1 = SemVer.parse("1.3.0+L2")
+        assertNotNull(version1)
+        assertEquals("L2", version1.buildMetadata)
+
+        val version2 = SemVer.parse("2.15.0-255-internal+L3", true)
+        assertNotEquals(SemVer(2, 15, 0, "255-internal", "L3"), version2)
+        assertEquals(SemVer(2, 15, 0), version2)
+
+        val version3 = SemVer.parse("2.15.0-255-internal+L3")
+        assertEquals(SemVer(2, 15, 0, "255-internal", "L3"), version3)
+    }
+
+    @Test
     fun `parse (versionString, ignoreExtensions) should return SemVer`() {
         val version1 = SemVer.parse("2.15.0", true)
         assertEquals(SemVer(2, 15, 0), version1)


### PR DESCRIPTION

Changes proposed in this pull request:
- Adjust SemVer to handle build meta data
- Accept all safes with contract version >= 1.0.0
- Parse & use chain short name to handle EIP-3770 addresses input
- DB adjustments & migrations
- Tests

@gnosis/mobile-devs
