### PR TITLE
[Send funds] Send asset screen

### DIFF
--- a/app/src/main/java/io/gnosis/safe/Tracker.kt
+++ b/app/src/main/java/io/gnosis/safe/Tracker.kt
@@ -241,6 +241,7 @@ enum class ScreenId(val value: String) {
     ASSETS_NO_SAFE("screen_assets_no_safe"),
     ASSETS_COINS("screen_assets_coins"),
     ASSETS_COINS_TRANSFER_SELECT("screen_assets_coins_transfer_select"),
+    ASSETS_COINS_TRANSFER("screen_asset_transfer"),
     ASSETS_COINS_TRANSFER_ADVANCED_PARAMS("screen_asset_transfer_advanced_params"),
     ASSETS_COINS_TRANSFER_SUCCESS("screen_asset_transfer_success"),
     ASSETS_COLLECTIBLES("screen_assets_collectibles"),

--- a/app/src/main/java/io/gnosis/safe/di/components/ViewComponent.kt
+++ b/app/src/main/java/io/gnosis/safe/di/components/ViewComponent.kt
@@ -16,6 +16,7 @@ import io.gnosis.safe.ui.safe.add.AddSafeOwnerFragment
 import io.gnosis.safe.ui.safe.selection.SafeSelectionDialog
 import io.gnosis.safe.ui.safe.send_funds.AssetSelectionFragment
 import io.gnosis.safe.ui.safe.send_funds.EditAdvancedParamsFragment
+import io.gnosis.safe.ui.safe.send_funds.SendAssetFragment
 import io.gnosis.safe.ui.safe.send_funds.SuccessFragment
 import io.gnosis.safe.ui.safe.share.ShareSafeDialog
 import io.gnosis.safe.ui.settings.SettingsFragment
@@ -135,6 +136,8 @@ interface ViewComponent {
     fun inject(fragment: AssetsFragment)
 
     fun inject(fragment: AssetSelectionFragment)
+
+    fun inject(fragment: SendAssetFragment)
 
     fun inject(fragment: EditAdvancedParamsFragment)
 

--- a/app/src/main/java/io/gnosis/safe/di/modules/ViewModelFactoryModule.kt
+++ b/app/src/main/java/io/gnosis/safe/di/modules/ViewModelFactoryModule.kt
@@ -16,6 +16,7 @@ import io.gnosis.safe.ui.safe.add.AddSafeNameViewModel
 import io.gnosis.safe.ui.safe.add.AddSafeViewModel
 import io.gnosis.safe.ui.safe.selection.SafeSelectionViewModel
 import io.gnosis.safe.ui.safe.send_funds.AssetSelectionViewModel
+import io.gnosis.safe.ui.safe.send_funds.SendAssetViewModel
 import io.gnosis.safe.ui.safe.share.ShareSafeViewModel
 import io.gnosis.safe.ui.settings.SettingsViewModel
 import io.gnosis.safe.ui.settings.app.AppSettingsViewModel
@@ -27,8 +28,8 @@ import io.gnosis.safe.ui.settings.owner.OwnerEnterNameViewModel
 import io.gnosis.safe.ui.settings.owner.OwnerSeedPhraseViewModel
 import io.gnosis.safe.ui.settings.owner.details.OwnerDetailsViewModel
 import io.gnosis.safe.ui.settings.owner.intro.OwnerGenerateViewModel
-import io.gnosis.safe.ui.settings.owner.ledger.LedgerOwnerSelectionViewModel
 import io.gnosis.safe.ui.settings.owner.ledger.LedgerDeviceListViewModel
+import io.gnosis.safe.ui.settings.owner.ledger.LedgerOwnerSelectionViewModel
 import io.gnosis.safe.ui.settings.owner.ledger.LedgerSignViewModel
 import io.gnosis.safe.ui.settings.owner.list.OwnerListViewModel
 import io.gnosis.safe.ui.settings.owner.selection.OwnerSelectionViewModel
@@ -96,6 +97,11 @@ abstract class ViewModelFactoryModule {
     @IntoMap
     @ViewModelKey(AssetSelectionViewModel::class)
     abstract fun providesAssetSelectionViewModel(viewModel: AssetSelectionViewModel): ViewModel
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(SendAssetViewModel::class)
+    abstract fun providesSendAssetViewModel(viewModel: SendAssetViewModel): ViewModel
 
     @Binds
     @IntoMap

--- a/app/src/main/java/io/gnosis/safe/di/modules/ViewModule.kt
+++ b/app/src/main/java/io/gnosis/safe/di/modules/ViewModule.kt
@@ -20,6 +20,7 @@ import io.gnosis.safe.ui.safe.add.AddSafeViewModel
 import io.gnosis.safe.ui.safe.selection.SafeSelectionAdapter
 import io.gnosis.safe.ui.safe.selection.SafeSelectionViewModel
 import io.gnosis.safe.ui.safe.send_funds.AssetSelectionViewModel
+import io.gnosis.safe.ui.safe.send_funds.SendAssetViewModel
 import io.gnosis.safe.ui.safe.share.ShareSafeViewModel
 import io.gnosis.safe.ui.settings.SettingsViewModel
 import io.gnosis.safe.ui.settings.app.AppSettingsViewModel
@@ -31,8 +32,8 @@ import io.gnosis.safe.ui.settings.owner.OwnerEnterNameViewModel
 import io.gnosis.safe.ui.settings.owner.OwnerSeedPhraseViewModel
 import io.gnosis.safe.ui.settings.owner.details.OwnerDetailsViewModel
 import io.gnosis.safe.ui.settings.owner.intro.OwnerGenerateViewModel
-import io.gnosis.safe.ui.settings.owner.ledger.LedgerOwnerSelectionViewModel
 import io.gnosis.safe.ui.settings.owner.ledger.LedgerDeviceListViewModel
+import io.gnosis.safe.ui.settings.owner.ledger.LedgerOwnerSelectionViewModel
 import io.gnosis.safe.ui.settings.owner.ledger.LedgerSignViewModel
 import io.gnosis.safe.ui.settings.owner.list.OwnerListViewModel
 import io.gnosis.safe.ui.settings.owner.selection.OwnerSelectionViewModel
@@ -130,6 +131,10 @@ class ViewModule(
     @Provides
     @ForView
     fun providesAssetSelectionViewModel(provider: ViewModelProvider) = provider[AssetSelectionViewModel::class.java]
+
+    @Provides
+    @ForView
+    fun providesSendAssetViewModel(provider: ViewModelProvider) = provider[SendAssetViewModel::class.java]
 
     @Provides
     @ForView

--- a/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsAdapter.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsAdapter.kt
@@ -109,8 +109,8 @@ class CoinBalanceViewHolder(private val viewBinding: ItemCoinBalanceBinding) : B
         with(viewBinding) {
             logoImage.loadTokenLogo(icon = coinBalance.logoUri)
             symbol.text = coinBalance.symbol
-            balance.text = coinBalance.balance
-            balanceUsd.text = coinBalance.balanceFiat
+            balance.text = coinBalance.balanceFormatted
+            balanceUsd.text = coinBalance.balanceFiatFormatted
             assetOnClickListener?.let {
                 root.setOnClickListener {
                     assetOnClickListener?.get()?.onAssetClicked(coinBalance)

--- a/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsViewData.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsViewData.kt
@@ -1,13 +1,18 @@
 package io.gnosis.safe.ui.assets.coins
 
+import java.io.Serializable
+import java.math.BigDecimal
 
-sealed class CoinsViewData {
+
+sealed class CoinsViewData : Serializable {
 
     data class CoinBalance(
+        val address: String,
         val symbol: String,
         val logoUri: String?,
-        val balance: String,
-        val balanceFiat: String
+        val balance: BigDecimal,
+        val balanceFormatted: String,
+        val balanceFiatFormatted: String
     ) : CoinsViewData()
 
     data class TotalBalance(

--- a/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsViewModel.kt
@@ -12,6 +12,7 @@ import io.gnosis.safe.ui.settings.app.SettingsHandler
 import io.gnosis.safe.utils.BalanceFormatter
 import io.gnosis.safe.utils.convertAmount
 import kotlinx.coroutines.flow.collect
+import pm.gnosis.crypto.utils.asEthereumAddressChecksumString
 import java.math.RoundingMode
 import javax.inject.Inject
 
@@ -92,8 +93,10 @@ class CoinsViewModel
         coinBalanceData.items.forEach {
             result.add(
                 CoinsViewData.CoinBalance(
+                    it.tokenInfo.address.asEthereumAddressChecksumString(),
                     it.tokenInfo.symbol,
                     it.tokenInfo.logoUri,
+                    it.balance.convertAmount(it.tokenInfo.decimals),
                     balanceFormatter.shortAmount(it.balance.convertAmount(it.tokenInfo.decimals)),
                     balanceFormatter.fiatBalanceWithCurrency(
                         it.fiatBalance.setScale(2, RoundingMode.HALF_UP),

--- a/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeFragment.kt
@@ -79,13 +79,13 @@ class AddSafeFragment : BaseViewBindingFragment<FragmentAddSafeBinding>() {
             }
         }
 
-        viewModel.state.observe(viewLifecycleOwner, Observer { state ->
+        viewModel.state.observe(viewLifecycleOwner) { state ->
             when (val action = state.viewAction) {
                 is ShowValidSafe -> handleValid(action.safe.address)
                 is BaseStateViewModel.ViewAction.Loading -> binding.progress.visible(action.isLoading)
                 is BaseStateViewModel.ViewAction.ShowError -> handleError(action.error)
             }
-        })
+        }
     }
 
     override fun onStop() {

--- a/app/src/main/java/io/gnosis/safe/ui/safe/add/SafeInputView.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/add/SafeInputView.kt
@@ -25,6 +25,13 @@ class SafeInputView @JvmOverloads constructor(
     var address: Solidity.Address? = null
         private set
 
+    var hint: String = context.getString(R.string.enter_safe_address)
+        set(value) {
+            binding.address.text = value
+            field = value
+        }
+
+
     fun setNewAddress(newAddress: Solidity.Address) {
 
         address = newAddress
@@ -34,7 +41,13 @@ class SafeInputView @JvmOverloads constructor(
             blockies.setAddress(newAddress)
             blockies.visible(true)
             address.text = newAddress.formatEthAddress(context, addMiddleLinebreak = false)
-            mainContainer.backgroundTintList = ColorStateList.valueOf(ResourcesCompat.getColor(resources, R.color.outline, context.theme))
+            mainContainer.backgroundTintList = ColorStateList.valueOf(
+                ResourcesCompat.getColor(
+                    resources,
+                    R.color.outline,
+                    context.theme
+                )
+            )
         }
     }
 
@@ -56,17 +69,35 @@ class SafeInputView @JvmOverloads constructor(
                     blockies.setAddress(null)
                     blockies.visible(false)
                     if (input.isBlank()) {
-                        address.setTextColor(ResourcesCompat.getColor(resources, R.color.label_tertiary, context.theme))
-                        address.text = context.getString(R.string.enter_safe_address)
+                        address.setTextColor(
+                            ResourcesCompat.getColor(
+                                resources,
+                                R.color.label_tertiary,
+                                context.theme
+                            )
+                        )
+                        address.text = hint
 
                     } else {
-                        address.setTextColor(ResourcesCompat.getColor(resources, R.color.label_primary, context.theme))
+                        address.setTextColor(
+                            ResourcesCompat.getColor(
+                                resources,
+                                R.color.label_primary,
+                                context.theme
+                            )
+                        )
                         address.text = input
                     }
                 }
             }
 
-            mainContainer.backgroundTintList = ColorStateList.valueOf(ResourcesCompat.getColor(resources, R.color.error, context.theme))
+            mainContainer.backgroundTintList = ColorStateList.valueOf(
+                ResourcesCompat.getColor(
+                    resources,
+                    R.color.error,
+                    context.theme
+                )
+            )
         }
     }
 

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/AssetSelectionViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/AssetSelectionViewModel.kt
@@ -103,7 +103,8 @@ class AssetSelectionViewModel
                 AssetSelectionState(
                     loading = false,
                     //viewAction = ViewAction.NavigateTo(AssetSelectionFragmentDirections.actionAssetSelectionFragmentToSuccessFragment(safe.chain, "", "22", "SAFE"))
-                    viewAction = ViewAction.NavigateTo(AssetSelectionFragmentDirections.actionAssetSelectionFragmentToEditAdvancedParamsFragment(safe.chain, "5", "1"))
+                   // viewAction = ViewAction.NavigateTo(AssetSelectionFragmentDirections.actionAssetSelectionFragmentToEditAdvancedParamsFragment(safe.chain, "5", "1"))
+                    viewAction = ViewAction.NavigateTo(AssetSelectionFragmentDirections.actionAssetSelectionFragmentToSendAssetFragment(safe.chain))
                 )
             }
             updateState {

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/AssetSelectionViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/AssetSelectionViewModel.kt
@@ -10,6 +10,7 @@ import io.gnosis.safe.ui.base.BaseStateViewModel
 import io.gnosis.safe.ui.settings.app.SettingsHandler
 import io.gnosis.safe.utils.BalanceFormatter
 import io.gnosis.safe.utils.convertAmount
+import pm.gnosis.crypto.utils.asEthereumAddressChecksumString
 import java.math.RoundingMode
 import javax.inject.Inject
 
@@ -81,8 +82,10 @@ class AssetSelectionViewModel
         balances.forEach {
             result.add(
                 CoinsViewData.CoinBalance(
+                    it.tokenInfo.address.asEthereumAddressChecksumString(),
                     it.tokenInfo.symbol,
                     it.tokenInfo.logoUri,
+                    it.balance.convertAmount(it.tokenInfo.decimals),
                     balanceFormatter.shortAmount(it.balance.convertAmount(it.tokenInfo.decimals)),
                     balanceFormatter.fiatBalanceWithCurrency(
                         it.fiatBalance.setScale(2, RoundingMode.HALF_UP),
@@ -104,7 +107,7 @@ class AssetSelectionViewModel
                     loading = false,
                     //viewAction = ViewAction.NavigateTo(AssetSelectionFragmentDirections.actionAssetSelectionFragmentToSuccessFragment(safe.chain, "", "22", "SAFE"))
                    // viewAction = ViewAction.NavigateTo(AssetSelectionFragmentDirections.actionAssetSelectionFragmentToEditAdvancedParamsFragment(safe.chain, "5", "1"))
-                    viewAction = ViewAction.NavigateTo(AssetSelectionFragmentDirections.actionAssetSelectionFragmentToSendAssetFragment(safe.chain))
+                    viewAction = ViewAction.NavigateTo(AssetSelectionFragmentDirections.actionAssetSelectionFragmentToSendAssetFragment(safe.chain, asset))
                 )
             }
             updateState {

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/AssetSelectionViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/AssetSelectionViewModel.kt
@@ -105,8 +105,6 @@ class AssetSelectionViewModel
                 //TODO: pass selected asset and proceed with the flow
                 AssetSelectionState(
                     loading = false,
-                    //viewAction = ViewAction.NavigateTo(AssetSelectionFragmentDirections.actionAssetSelectionFragmentToSuccessFragment(safe.chain, "", "22", "SAFE"))
-                   // viewAction = ViewAction.NavigateTo(AssetSelectionFragmentDirections.actionAssetSelectionFragmentToEditAdvancedParamsFragment(safe.chain, "5", "1"))
                     viewAction = ViewAction.NavigateTo(AssetSelectionFragmentDirections.actionAssetSelectionFragmentToSendAssetFragment(safe.chain, asset))
                 )
             }

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import androidx.navigation.Navigation
 import androidx.navigation.fragment.navArgs
 import io.gnosis.safe.R
@@ -20,6 +21,7 @@ import pm.gnosis.model.Solidity
 import pm.gnosis.utils.asEthereumAddressString
 import timber.log.Timber
 import javax.inject.Inject
+
 
 class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
 
@@ -85,6 +87,7 @@ class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
                 addressInputHelper.showDialog()
             }
             balanceValue.text = "${selectedAsset.balanceFormatted} ${selectedAsset.symbol}"
+            assetSendAmount.setAssetLogo(selectedAsset.logoUri)
             sendMax.setOnClickListener {
 
             }
@@ -104,6 +107,16 @@ class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
                 }
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
     }
 
     private fun updateAddress(address: Solidity.Address) {

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
@@ -69,6 +69,7 @@ class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
                     R.color.primary
                 )
             )
+            recepientAddressInputLayout.hint = getString(R.string.coins_asset_send_recepient)
             recepientAddressInputLayout.setOnClickListener {
                 addressInputHelper.showDialog()
             }

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
@@ -10,8 +10,10 @@ import io.gnosis.safe.R
 import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentSendAssetBinding
 import io.gnosis.safe.di.components.ViewComponent
+import io.gnosis.safe.helpers.AddressInputHelper
 import io.gnosis.safe.ui.base.fragment.BaseViewBindingFragment
 import io.gnosis.safe.utils.toColor
+import pm.gnosis.model.Solidity
 import javax.inject.Inject
 
 class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
@@ -25,6 +27,18 @@ class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
 
     @Inject
     lateinit var viewModel: SendAssetViewModel
+
+    private val addressInputHelper by lazy {
+        AddressInputHelper(
+            fragment = this,
+            tracker = tracker,
+            selectedChain = selectedChain,
+            addressCallback = ::updateAddress,
+            errorCallback = ::handleError,
+            enableUD = viewModel.enableUD(selectedChain),
+            enableENS = viewModel.enableENS(selectedChain)
+        )
+    }
 
     override fun inject(component: ViewComponent) {
         component.inject(this)
@@ -55,6 +69,21 @@ class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
                     R.color.primary
                 )
             )
+            recepientAddressInputLayout.setOnClickListener {
+                addressInputHelper.showDialog()
+            }
         }
+    }
+
+    private fun updateAddress(address: Solidity.Address) {
+
+    }
+
+    private fun handleValid(address: Solidity.Address) {
+
+    }
+
+    private fun handleError(throwable: Throwable, input: String? = null) {
+
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
@@ -21,12 +21,12 @@ import javax.inject.Inject
 class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
 
     private val navArgs by navArgs<SendAssetFragmentArgs>()
-    private val selectedChain by lazy { navArgs.chain }
+    private val chain by lazy { navArgs.chain }
     private val selectedAsset by lazy { navArgs.selectedAsset as CoinsViewData.CoinBalance }
 
     override fun screenId() = ScreenId.ASSETS_COINS_TRANSFER
 
-    override suspend fun chainId() = selectedChain.chainId
+    override suspend fun chainId() = chain.chainId
 
     @Inject
     lateinit var viewModel: SendAssetViewModel
@@ -35,11 +35,11 @@ class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
         AddressInputHelper(
             fragment = this,
             tracker = tracker,
-            selectedChain = selectedChain,
+            selectedChain = chain,
             addressCallback = ::updateAddress,
             errorCallback = ::handleError,
-            enableUD = viewModel.enableUD(selectedChain),
-            enableENS = viewModel.enableENS(selectedChain)
+            enableUD = viewModel.enableUD(chain),
+            enableENS = viewModel.enableENS(chain)
         )
     }
 
@@ -61,15 +61,15 @@ class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
             backButton.setOnClickListener {
                 Navigation.findNavController(it).navigateUp()
             }
-            chainRibbon.text = selectedChain.name
+            chainRibbon.text = chain.name
             chainRibbon.setTextColor(
-                selectedChain.textColor.toColor(
+                chain.textColor.toColor(
                     requireContext(),
                     R.color.white
                 )
             )
             chainRibbon.setBackgroundColor(
-                selectedChain.backgroundColor.toColor(
+                chain.backgroundColor.toColor(
                     requireContext(),
                     R.color.primary
                 )
@@ -78,6 +78,10 @@ class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
             recepientAddressInputLayout.hint = getString(R.string.coins_asset_send_recepient)
             recepientAddressInputLayout.setOnClickListener {
                 addressInputHelper.showDialog()
+            }
+            balanceValue.text = "${selectedAsset.balanceFormatted} ${selectedAsset.symbol}"
+            sendMax.setOnClickListener {
+
             }
         }
 
@@ -88,7 +92,7 @@ class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
                         when (action) {
                             is UpdateActiveSafe -> {
                                 binding.senderItem.name = action.newSafe!!.localName
-                                binding.senderItem.setAddress(selectedChain, action.newSafe.address)
+                                binding.senderItem.setAddress(chain, action.newSafe.address)
                             }
                         }
                     }

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
+import androidx.core.widget.doOnTextChanged
 import androidx.navigation.Navigation
 import androidx.navigation.fragment.navArgs
 import io.gnosis.safe.R
@@ -19,6 +20,7 @@ import io.gnosis.safe.ui.base.fragment.BaseViewBindingFragment
 import io.gnosis.safe.utils.toColor
 import pm.gnosis.model.Solidity
 import pm.gnosis.utils.asEthereumAddressString
+import pm.gnosis.utils.nullOnThrow
 import timber.log.Timber
 import java.math.BigDecimal
 import javax.inject.Inject
@@ -90,6 +92,9 @@ class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
             }
             balanceValue.text = "${selectedAsset.balanceFormatted} ${selectedAsset.symbol}"
             assetSendAmount.setAssetLogo(selectedAsset.logoUri)
+            assetSendAmount.doOnTextChanged { text, _, _, _ ->
+                amountInput = nullOnThrow { BigDecimal(text.toString()) }
+            }
             sendMax.setOnClickListener {
                 amountInput = selectedAsset.balance
                 assetSendAmount.setAmount(selectedAsset.balance)

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
@@ -20,6 +20,7 @@ import io.gnosis.safe.utils.toColor
 import pm.gnosis.model.Solidity
 import pm.gnosis.utils.asEthereumAddressString
 import timber.log.Timber
+import java.math.BigDecimal
 import javax.inject.Inject
 
 
@@ -49,6 +50,7 @@ class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
     }
 
     private var recipientInput: String? = null
+    private var amountInput: BigDecimal? = null
 
     override fun inject(component: ViewComponent) {
         component.inject(this)
@@ -89,7 +91,8 @@ class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
             balanceValue.text = "${selectedAsset.balanceFormatted} ${selectedAsset.symbol}"
             assetSendAmount.setAssetLogo(selectedAsset.logoUri)
             sendMax.setOnClickListener {
-
+                amountInput = selectedAsset.balance
+                assetSendAmount.setAmount(selectedAsset.balance)
             }
         }
 

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
@@ -1,0 +1,60 @@
+package io.gnosis.safe.ui.safe.send_funds
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.navigation.Navigation
+import androidx.navigation.fragment.navArgs
+import io.gnosis.safe.R
+import io.gnosis.safe.ScreenId
+import io.gnosis.safe.databinding.FragmentSendAssetBinding
+import io.gnosis.safe.di.components.ViewComponent
+import io.gnosis.safe.ui.base.fragment.BaseViewBindingFragment
+import io.gnosis.safe.utils.toColor
+import javax.inject.Inject
+
+class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
+
+    private val navArgs by navArgs<SendAssetFragmentArgs>()
+    private val selectedChain by lazy { navArgs.chain }
+
+    override fun screenId() = ScreenId.ASSETS_COINS_TRANSFER
+
+    override suspend fun chainId() = selectedChain.chainId
+
+    @Inject
+    lateinit var viewModel: SendAssetViewModel
+
+    override fun inject(component: ViewComponent) {
+        component.inject(this)
+    }
+
+    override fun inflateBinding(
+        inflater: LayoutInflater,
+        container: ViewGroup?
+    ): FragmentSendAssetBinding =
+        FragmentSendAssetBinding.inflate(inflater, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        with(binding) {
+            backButton.setOnClickListener {
+                Navigation.findNavController(it).navigateUp()
+            }
+            chainRibbon.text = selectedChain.name
+            chainRibbon.setTextColor(
+                selectedChain.textColor.toColor(
+                    requireContext(),
+                    R.color.white
+                )
+            )
+            chainRibbon.setBackgroundColor(
+                selectedChain.backgroundColor.toColor(
+                    requireContext(),
+                    R.color.primary
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
@@ -11,6 +11,7 @@ import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentSendAssetBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.helpers.AddressInputHelper
+import io.gnosis.safe.ui.assets.coins.CoinsViewData
 import io.gnosis.safe.ui.base.fragment.BaseViewBindingFragment
 import io.gnosis.safe.utils.toColor
 import pm.gnosis.model.Solidity
@@ -20,6 +21,7 @@ class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
 
     private val navArgs by navArgs<SendAssetFragmentArgs>()
     private val selectedChain by lazy { navArgs.chain }
+    private val selectedAsset by lazy { navArgs.selectedAsset as CoinsViewData.CoinBalance }
 
     override fun screenId() = ScreenId.ASSETS_COINS_TRANSFER
 
@@ -52,7 +54,9 @@ class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
         with(binding) {
+            title.text = getString(R.string.coins_asset_send, selectedAsset.symbol)
             backButton.setOnClickListener {
                 Navigation.findNavController(it).navigateUp()
             }
@@ -73,6 +77,10 @@ class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
             recepientAddressInputLayout.setOnClickListener {
                 addressInputHelper.showDialog()
             }
+        }
+
+        viewModel.state.observe(viewLifecycleOwner) {
+
         }
     }
 

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
@@ -5,7 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
-import androidx.core.widget.doOnTextChanged
 import androidx.navigation.Navigation
 import androidx.navigation.fragment.navArgs
 import io.gnosis.safe.R
@@ -94,6 +93,7 @@ class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
             assetSendAmount.setAssetLogo(selectedAsset.logoUri)
             assetSendAmount.doOnTextChanged { text, _, _, _ ->
                 amountInput = nullOnThrow { BigDecimal(text.toString()) }
+                reviewButton.isEnabled = viewModel.validateInputs(recipientInput, amountInput)
             }
             sendMax.setOnClickListener {
                 amountInput = selectedAsset.balance
@@ -130,8 +130,7 @@ class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
     private fun updateAddress(address: Solidity.Address) {
         recipientInput = address.asEthereumAddressString()
         with(binding) {
-            //TODO: check if review button can be enabled
-            reviewButton.isEnabled = false
+            reviewButton.isEnabled = viewModel.validateInputs(recipientInput, amountInput)
             recipientAddressInputLayout.setNewAddress(address)
         }
     }
@@ -141,8 +140,7 @@ class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
             if (recipientAddressInputLayout.address == null) {
                 recipientAddressInputLayout.setNewAddress(address)
             }
-            //TODO: check if review button can be enabled
-            reviewButton.isEnabled = true
+            reviewButton.isEnabled = viewModel.validateInputs(recipientInput, amountInput)
         }
     }
 

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetFragment.kt
@@ -12,6 +12,7 @@ import io.gnosis.safe.databinding.FragmentSendAssetBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.helpers.AddressInputHelper
 import io.gnosis.safe.ui.assets.coins.CoinsViewData
+import io.gnosis.safe.ui.base.BaseStateViewModel.ViewAction.*
 import io.gnosis.safe.ui.base.fragment.BaseViewBindingFragment
 import io.gnosis.safe.utils.toColor
 import pm.gnosis.model.Solidity
@@ -73,14 +74,26 @@ class SendAssetFragment : BaseViewBindingFragment<FragmentSendAssetBinding>() {
                     R.color.primary
                 )
             )
+            senderItem.showLink = false
             recepientAddressInputLayout.hint = getString(R.string.coins_asset_send_recepient)
             recepientAddressInputLayout.setOnClickListener {
                 addressInputHelper.showDialog()
             }
         }
 
-        viewModel.state.observe(viewLifecycleOwner) {
-
+        viewModel.state.observe(viewLifecycleOwner) { state ->
+            when (state) {
+                is SendAssetState -> {
+                    state.viewAction?.let { action ->
+                        when (action) {
+                            is UpdateActiveSafe -> {
+                                binding.senderItem.name = action.newSafe!!.localName
+                                binding.senderItem.setAddress(selectedChain, action.newSafe.address)
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetViewModel.kt
@@ -1,17 +1,29 @@
 package io.gnosis.safe.ui.safe.send_funds
 
+import io.gnosis.data.models.Chain
+import io.gnosis.data.repositories.EnsRepository
+import io.gnosis.data.repositories.UnstoppableDomainsRepository
 import io.gnosis.safe.ui.base.AppDispatchers
 import io.gnosis.safe.ui.base.BaseStateViewModel
 import javax.inject.Inject
 
 class SendAssetViewModel
 @Inject constructor(
+    private val unstoppableDomainsRepository: UnstoppableDomainsRepository,
+    private val ensRepository: EnsRepository,
     appDispatchers: AppDispatchers
 ) : BaseStateViewModel<SendAssetState>(appDispatchers) {
 
     override fun initialState(): SendAssetState =
         SendAssetState(viewAction = null)
 
+    fun enableUD(chain: Chain): Boolean {
+        return unstoppableDomainsRepository.canResolve(chain)
+    }
+
+    fun enableENS(chain: Chain): Boolean {
+        return ensRepository.canResolve(chain)
+    }
 }
 
 data class SendAssetState(

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetViewModel.kt
@@ -9,6 +9,9 @@ import io.gnosis.safe.ui.assets.SafeBalancesState
 import io.gnosis.safe.ui.base.AppDispatchers
 import io.gnosis.safe.ui.base.BaseStateViewModel
 import kotlinx.coroutines.flow.collect
+import pm.gnosis.utils.asEthereumAddress
+import java.math.BigDecimal
+import java.math.BigInteger
 import javax.inject.Inject
 
 class SendAssetViewModel
@@ -34,6 +37,11 @@ class SendAssetViewModel
                 }
             }
         }
+    }
+
+    fun validateInputs(recipientInput: String?, amountInput: BigDecimal?): Boolean {
+        val address = recipientInput?.asEthereumAddress()
+        return address != null && amountInput != null
     }
 
     fun enableUD(chain: Chain): Boolean {

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetViewModel.kt
@@ -1,21 +1,40 @@
 package io.gnosis.safe.ui.safe.send_funds
 
 import io.gnosis.data.models.Chain
+import io.gnosis.data.models.Safe
 import io.gnosis.data.repositories.EnsRepository
+import io.gnosis.data.repositories.SafeRepository
 import io.gnosis.data.repositories.UnstoppableDomainsRepository
+import io.gnosis.safe.ui.assets.SafeBalancesState
 import io.gnosis.safe.ui.base.AppDispatchers
 import io.gnosis.safe.ui.base.BaseStateViewModel
+import kotlinx.coroutines.flow.collect
 import javax.inject.Inject
 
 class SendAssetViewModel
 @Inject constructor(
+    private val safeRepository: SafeRepository,
     private val unstoppableDomainsRepository: UnstoppableDomainsRepository,
     private val ensRepository: EnsRepository,
     appDispatchers: AppDispatchers
 ) : BaseStateViewModel<SendAssetState>(appDispatchers) {
 
+    var activeSafe: Safe? = null
+        private set
+
     override fun initialState(): SendAssetState =
         SendAssetState(viewAction = null)
+
+    init {
+        safeLaunch {
+            safeRepository.activeSafeFlow().collect { safe ->
+                updateState {
+                    activeSafe = safe
+                    SendAssetState(viewAction = ViewAction.UpdateActiveSafe(activeSafe))
+                }
+            }
+        }
+    }
 
     fun enableUD(chain: Chain): Boolean {
         return unstoppableDomainsRepository.canResolve(chain)

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/SendAssetViewModel.kt
@@ -1,0 +1,19 @@
+package io.gnosis.safe.ui.safe.send_funds
+
+import io.gnosis.safe.ui.base.AppDispatchers
+import io.gnosis.safe.ui.base.BaseStateViewModel
+import javax.inject.Inject
+
+class SendAssetViewModel
+@Inject constructor(
+    appDispatchers: AppDispatchers
+) : BaseStateViewModel<SendAssetState>(appDispatchers) {
+
+    override fun initialState(): SendAssetState =
+        SendAssetState(viewAction = null)
+
+}
+
+data class SendAssetState(
+    override var viewAction: BaseStateViewModel.ViewAction?
+) : BaseStateViewModel.State

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/view/AssetAmountInputView.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/view/AssetAmountInputView.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
 import io.gnosis.safe.databinding.ViewAssetAmountInputBinding
 import io.gnosis.safe.utils.loadTokenLogo
+import java.math.BigDecimal
 
 class AssetAmountInputView@JvmOverloads constructor(
     context: Context,
@@ -17,5 +18,9 @@ class AssetAmountInputView@JvmOverloads constructor(
 
     fun setAssetLogo(logoUri: String?) {
         binding.assetLogo.loadTokenLogo(icon = logoUri)
+    }
+
+    fun setAmount(amount: BigDecimal) {
+        binding.amount.setText(amount.stripTrailingZeros().toPlainString())
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/view/AssetAmountInputView.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/view/AssetAmountInputView.kt
@@ -1,14 +1,16 @@
 package io.gnosis.safe.ui.safe.send_funds.view
 
 import android.content.Context
+import android.text.TextWatcher
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.widget.doOnTextChanged
 import io.gnosis.safe.databinding.ViewAssetAmountInputBinding
 import io.gnosis.safe.utils.loadTokenLogo
 import java.math.BigDecimal
 
-class AssetAmountInputView@JvmOverloads constructor(
+class AssetAmountInputView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
@@ -22,5 +24,16 @@ class AssetAmountInputView@JvmOverloads constructor(
 
     fun setAmount(amount: BigDecimal) {
         binding.amount.setText(amount.stripTrailingZeros().toPlainString())
+    }
+
+    fun doOnTextChanged(
+        action: (
+            text: CharSequence?,
+            start: Int,
+            before: Int,
+            count: Int
+        ) -> Unit
+    ): TextWatcher {
+        return binding.amount.doOnTextChanged(action)
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/view/AssetAmountInputView.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/view/AssetAmountInputView.kt
@@ -2,12 +2,20 @@ package io.gnosis.safe.ui.safe.send_funds.view
 
 import android.content.Context
 import android.util.AttributeSet
-import android.widget.LinearLayout
+import android.view.LayoutInflater
+import androidx.constraintlayout.widget.ConstraintLayout
+import io.gnosis.safe.databinding.ViewAssetAmountInputBinding
+import io.gnosis.safe.utils.loadTokenLogo
 
 class AssetAmountInputView@JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
-) : LinearLayout(context, attrs, defStyleAttr) {
+) : ConstraintLayout(context, attrs, defStyleAttr) {
 
+    private val binding = ViewAssetAmountInputBinding.inflate(LayoutInflater.from(context), this)
+
+    fun setAssetLogo(logoUri: String?) {
+        binding.assetLogo.loadTokenLogo(icon = logoUri)
+    }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/view/AssetAmountInputView.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/send_funds/view/AssetAmountInputView.kt
@@ -1,0 +1,13 @@
+package io.gnosis.safe.ui.safe.send_funds.view
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.LinearLayout
+
+class AssetAmountInputView@JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : LinearLayout(context, attrs, defStyleAttr) {
+
+}

--- a/app/src/main/java/io/gnosis/safe/ui/settings/view/NamedAddressItem.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/view/NamedAddressItem.kt
@@ -25,7 +25,12 @@ class NamedAddressItem @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : ConstraintLayout(context, attrs, defStyleAttr) {
 
-    private val binding by lazy { ViewNamedAddressItemBinding.inflate(LayoutInflater.from(context), this) }
+    private val binding by lazy {
+        ViewNamedAddressItemBinding.inflate(
+            LayoutInflater.from(context),
+            this
+        )
+    }
 
     init {
         readAttributesAndSetupFields(context, attrs)
@@ -33,6 +38,12 @@ class NamedAddressItem @JvmOverloads constructor(
 
     var address: Solidity.Address? = null
         private set
+
+    var showLink: Boolean = true
+        set(value) {
+            binding.link.visible(value)
+            field = value
+        }
 
     fun setAddress(chain: Chain, value: Solidity.Address?, ownerType: Owner.Type? = null) {
         with(binding) {
@@ -43,7 +54,10 @@ class NamedAddressItem @JvmOverloads constructor(
             }
             root.setOnClickListener {
                 value?.let {
-                    context.copyToClipboard(context.getString(R.string.address_copied), value.asEthereumAddressChecksumString()) {
+                    context.copyToClipboard(
+                        context.getString(R.string.address_copied),
+                        value.asEthereumAddressChecksumString()
+                    ) {
                         snackbar(view = root, textId = R.string.copied_success)
                     }
                 }
@@ -90,7 +104,12 @@ class NamedAddressItem @JvmOverloads constructor(
         }
 
     private fun applyAttributes(context: Context, a: TypedArray) {
-        binding.namedAddressItemSeparator.visible(a.getBoolean(R.styleable.NamedAddressItem_show_named_address_separator, false))
+        binding.namedAddressItemSeparator.visible(
+            a.getBoolean(
+                R.styleable.NamedAddressItem_show_named_address_separator,
+                false
+            )
+        )
     }
 
     fun loadKnownAddressLogo(addressUri: String?, address: Solidity.Address?) {

--- a/app/src/main/res/layout/fragment_edit_advanced_params.xml
+++ b/app/src/main/res/layout/fragment_edit_advanced_params.xml
@@ -35,7 +35,7 @@
             android:layout_marginHorizontal="16dp"
             android:layout_weight="1"
             android:gravity="start"
-            android:text="@string/coins_asset_edit_params" />
+            android:text="@string/coins_asset_send_edit_params" />
 
         <TextView
             android:id="@+id/save_button"

--- a/app/src/main/res/layout/fragment_owner_name_edit.xml
+++ b/app/src/main/res/layout/fragment_owner_name_edit.xml
@@ -59,7 +59,6 @@
         app:layout_constraintTop_toBottomOf="@id/toolbar_layout"
         app:layout_constraintVertical_chainStyle="packed" />
 
-
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/owner_name_layout"
         style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"

--- a/app/src/main/res/layout/fragment_send_asset.xml
+++ b/app/src/main/res/layout/fragment_send_asset.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/background_secondary">
+
+    <LinearLayout
+        android:id="@+id/toolbar_layout"
+        style="@style/Toolbar"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageButton
+            android:id="@+id/back_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_weight="0"
+            android:background="@android:color/transparent"
+            android:gravity="center_vertical"
+            android:src="@drawable/ic_baseline_arrow_back_24" />
+
+        <TextView
+            android:id="@+id/title"
+            style="@style/ToolbarTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_weight="1"
+            android:gravity="start"
+            android:text="@string/coins_asset_send"
+            tools:text="Send ETH" />
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/chain_ribbon"
+        style="@style/ChainRibbon"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/chain_ribbon_size"
+        tools:text="Mainnet"
+        android:visibility="visible"
+        app:layout_constraintTop_toBottomOf="@id/toolbar_layout" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_marginTop="@dimen/default_small_margin"
+        app:layout_constraintTop_toBottomOf="@id/chain_ribbon">
+
+        <io.gnosis.safe.ui.settings.view.NamedAddressItem
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <io.gnosis.safe.ui.safe.add.SafeInputView
+            android:id="@+id/add_safe_address_input_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingHorizontal="16dp"
+            android:layout_marginTop="@dimen/default_margin"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/add_safe_label_top"
+            app:layout_constraintVertical_chainStyle="packed"
+            app:layout_constraintVertical_weight="0" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="horizontal"
+            android:layout_marginTop="@dimen/default_small_margin"
+            android:layout_marginHorizontal="@dimen/default_margin">
+
+            <TextView
+                style="@style/Body2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Balance:"
+                android:layout_marginLeft="4dp"
+                android:layout_marginRight="4dp"
+                android:layout_weight="0"/>
+
+            <TextView
+                style="@style/Body1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="0.01"
+                android:layout_weight="1"/>
+
+            <TextView
+                style="@style/TextLink"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Send max"
+                android:layout_marginRight="4dp"
+                android:layout_weight="0"/>
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <Button
+        android:id="@+id/review_button"
+        style="@style/PrimaryButton"
+        android:layout_width="match_parent"
+        android:layout_marginEnd="@dimen/default_margin"
+        android:layout_marginStart="@dimen/default_margin"
+        android:layout_marginBottom="24dp"
+        android:text="@string/add_safe_owner_add"
+        android:enabled="false"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_send_asset.xml
+++ b/app/src/main/res/layout/fragment_send_asset.xml
@@ -109,6 +109,12 @@
 
         </LinearLayout>
 
+        <io.gnosis.safe.ui.safe.send_funds.view.AssetAmountInputView
+            android:id="@+id/asset_send_amount"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/default_small_margin"/>
+
     </LinearLayout>
 
     <Button

--- a/app/src/main/res/layout/fragment_send_asset.xml
+++ b/app/src/main/res/layout/fragment_send_asset.xml
@@ -57,6 +57,7 @@
         app:layout_constraintTop_toBottomOf="@id/chain_ribbon">
 
         <io.gnosis.safe.ui.settings.view.NamedAddressItem
+            android:id="@+id/sender_item"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 

--- a/app/src/main/res/layout/fragment_send_asset.xml
+++ b/app/src/main/res/layout/fragment_send_asset.xml
@@ -84,7 +84,7 @@
                 style="@style/Body2"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Balance:"
+                android:text="@string/coins_asset_balance"
                 android:layout_marginLeft="4dp"
                 android:layout_marginRight="4dp"
                 android:layout_weight="0"/>
@@ -93,14 +93,14 @@
                 style="@style/Body1"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="0.01"
+                tools:text="0.01"
                 android:layout_weight="1"/>
 
             <TextView
                 style="@style/TextLink"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Send max"
+                android:text="@string/coins_asset_send_max"
                 android:layout_marginRight="4dp"
                 android:layout_weight="0"/>
 
@@ -115,7 +115,7 @@
         android:layout_marginEnd="@dimen/default_margin"
         android:layout_marginStart="@dimen/default_margin"
         android:layout_marginBottom="24dp"
-        android:text="@string/add_safe_owner_add"
+        android:text="@string/coins_asset_send_review"
         android:enabled="false"
         app:layout_constraintBottom_toBottomOf="parent" />
 

--- a/app/src/main/res/layout/fragment_send_asset.xml
+++ b/app/src/main/res/layout/fragment_send_asset.xml
@@ -91,6 +91,7 @@
                 android:layout_weight="0"/>
 
             <TextView
+                android:id="@+id/balance_value"
                 style="@style/Body1"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -98,6 +99,7 @@
                 android:layout_weight="1"/>
 
             <TextView
+                android:id="@+id/send_max"
                 style="@style/TextLink"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_send_asset.xml
+++ b/app/src/main/res/layout/fragment_send_asset.xml
@@ -61,7 +61,7 @@
             android:layout_height="wrap_content" />
 
         <io.gnosis.safe.ui.safe.add.SafeInputView
-            android:id="@+id/add_safe_address_input_layout"
+            android:id="@+id/recepient_address_input_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"

--- a/app/src/main/res/layout/fragment_send_asset.xml
+++ b/app/src/main/res/layout/fragment_send_asset.xml
@@ -62,7 +62,7 @@
             android:layout_height="wrap_content" />
 
         <io.gnosis.safe.ui.safe.add.SafeInputView
-            android:id="@+id/recepient_address_input_layout"
+            android:id="@+id/recipient_address_input_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"

--- a/app/src/main/res/layout/fragment_settings_safe_edit_name.xml
+++ b/app/src/main/res/layout/fragment_settings_safe_edit_name.xml
@@ -59,7 +59,6 @@
         app:layout_constraintTop_toBottomOf="@id/toolbar_layout"
         app:layout_constraintVertical_chainStyle="packed" />
 
-
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/safe_name_layout"
         style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"

--- a/app/src/main/res/layout/view_asset_amount_input.xml
+++ b/app/src/main/res/layout/view_asset_amount_input.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/view_asset_amount_input.xml
+++ b/app/src/main/res/layout/view_asset_amount_input.xml
@@ -1,6 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/amount_layout"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:textColorHint="@color/label_tertiary"
+        app:hintEnabled="false"
+        app:boxStrokeColor="@color/outline_box"
+        app:errorIconDrawable="@null"
+        app:errorTextColor="@color/error"
+        app:hintTextColor="@color/label_tertiary"
+        app:layout_constraintTop_toBottomOf="@id/toolbar_layout">
+
+        <EditText
+            android:id="@+id/amount"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:paddingLeft="64dp"
+            android:imeOptions="actionDone"
+            android:inputType="numberDecimal"
+            android:hint="@string/coins_asset_send_amount"
+            android:textColor="@color/label_primary"
+            android:textCursorDrawable="@drawable/cursor_drawable"/>
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.imageview.ShapeableImageView
+        android:id="@+id/asset_logo"
+        android:layout_width="28dp"
+        android:layout_height="28dp"
+        android:scaleType="centerInside"
+        app:layout_constraintBottom_toBottomOf="@id/amount_layout"
+        app:layout_constraintStart_toStartOf="@id/amount_layout"
+        android:layout_marginLeft="@dimen/default_margin"
+        app:layout_constraintTop_toTopOf="@id/amount_layout"
+        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.App.Circle"
+        app:strokeColor="@color/background_tertiary"
+        app:strokeWidth="0.1dp"
+        tools:src="@drawable/ic_native_logo" />
+
+</merge>

--- a/app/src/main/res/navigation/main_nav.xml
+++ b/app/src/main/res/navigation/main_nav.xml
@@ -88,6 +88,10 @@
             android:name="chain"
             app:argType="io.gnosis.data.models.Chain" />
 
+        <action
+            android:id="@+id/action_assetSelectionFragment_to_sendAssetFragment"
+            app:destination="@id/sendAssetFragment" />
+
         <!--TODO: remove -->
         <action
             android:id="@+id/action_assetSelectionFragment_to_successFragment"
@@ -95,6 +99,18 @@
         <action
             android:id="@+id/action_assetSelectionFragment_to_editAdvancedParamsFragment"
             app:destination="@id/editAdvancedParamsFragment" />
+
+    </fragment>
+
+    <fragment
+        android:id="@+id/sendAssetFragment"
+        android:name="io.gnosis.safe.ui.safe.send_funds.SendAssetFragment"
+        android:label="SendAssetFragment"
+        tools:layout="@layout/fragment_send_asset">
+
+        <argument
+            android:name="chain"
+            app:argType="io.gnosis.data.models.Chain" />
 
     </fragment>
 

--- a/app/src/main/res/navigation/main_nav.xml
+++ b/app/src/main/res/navigation/main_nav.xml
@@ -92,14 +92,6 @@
             android:id="@+id/action_assetSelectionFragment_to_sendAssetFragment"
             app:destination="@id/sendAssetFragment" />
 
-        <!--TODO: remove -->
-        <action
-            android:id="@+id/action_assetSelectionFragment_to_successFragment"
-            app:destination="@id/successFragment" />
-        <action
-            android:id="@+id/action_assetSelectionFragment_to_editAdvancedParamsFragment"
-            app:destination="@id/editAdvancedParamsFragment" />
-
     </fragment>
 
     <fragment

--- a/app/src/main/res/navigation/main_nav.xml
+++ b/app/src/main/res/navigation/main_nav.xml
@@ -112,6 +112,10 @@
             android:name="chain"
             app:argType="io.gnosis.data.models.Chain" />
 
+        <argument
+            android:name="selectedAsset"
+            app:argType="io.gnosis.safe.ui.assets.coins.CoinsViewData" />
+
     </fragment>
 
     <fragment

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -157,7 +157,11 @@
     <string name="coins_asset_select">Select an asset</string>
     <string name="coins_asset_not_found">No assets found.</string>
     <string name="coins_asset_send">Send %1$s</string>
-    <string name="coins_asset_edit_params">Edit advanced parameters</string>
+    <string name="coins_asset_balance">Balance:</string>
+    <string name="coins_asset_send_recepient">Recipient\'s address</string>
+    <string name="coins_asset_send_max">Send max</string>
+    <string name="coins_asset_send_review">Review</string>
+    <string name="coins_asset_send_edit_params">Edit advanced parameters</string>
 
     <string name="usd_balance">$ %1$s</string>
     <string name="coming_soon">Coming soon</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,6 +159,7 @@
     <string name="coins_asset_send">Send %1$s</string>
     <string name="coins_asset_balance">Balance:</string>
     <string name="coins_asset_send_recepient">Recipient\'s address</string>
+    <string name="coins_asset_send_amount">Amount</string>
     <string name="coins_asset_send_max">Send max</string>
     <string name="coins_asset_send_review">Review</string>
     <string name="coins_asset_send_edit_params">Edit advanced parameters</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,6 +156,7 @@
     <string name="coins_receive">Receive</string>
     <string name="coins_asset_select">Select an asset</string>
     <string name="coins_asset_not_found">No assets found.</string>
+    <string name="coins_asset_send">Send %1$s</string>
     <string name="coins_asset_edit_params">Edit advanced parameters</string>
 
     <string name="usd_balance">$ %1$s</string>


### PR DESCRIPTION
Handles #1784

Changes proposed in this pull request:
- Add send asset screen
- Pass selected asset data relevant for asset transfer
- Amount input field
- Tracking

<table>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/17750984/195839765-1ff16015-a731-4ed7-b04e-ca9f2127c3fd.png" width=400 />
</td>
<td>
<img src="https://user-images.githubusercontent.com/17750984/195840246-91f7f4db-d5fe-473b-ac35-ae30c2fa82e7.png" width=400 />
</td>
<td>
<img src="https://user-images.githubusercontent.com/17750984/195847328-046a4ce4-740d-428f-9339-adfed548b8f4.png" width=400 />
</td>
</tr>
</table>


@gnosis/mobile-devs
