### PR TITLE
Body1 versus Subtitle in select network & enter safe name screen

### DIFF
--- a/app/src/main/res/layout/fragment_add_safe.xml
+++ b/app/src/main/res/layout/fragment_add_safe.xml
@@ -70,7 +70,7 @@
 
     <TextView
         android:id="@+id/add_safe_label_top"
-        style="@style/Subtitle"
+        style="@style/Body1"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:gravity="center"

--- a/app/src/main/res/layout/fragment_chain_selection.xml
+++ b/app/src/main/res/layout/fragment_chain_selection.xml
@@ -69,7 +69,7 @@
 
                 <TextView
                     android:id="@+id/select_chain_title"
-                    style="@style/Subtitle"
+                    style="@style/Body1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:gravity="center"

--- a/app/src/main/res/layout/item_chain.xml
+++ b/app/src/main/res/layout/item_chain.xml
@@ -41,7 +41,7 @@
 
     <TextView
         android:id="@+id/name"
-        style="@style/Body1"
+        style="@style/Subtitle"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"


### PR DESCRIPTION
Handles #1820 

Changes proposed in this pull request:

Figma | light | dark
----- | ----  | ----
![image](https://user-images.githubusercontent.com/246473/196955950-fe5ba9e9-612d-4f51-bb5d-387d0a0af82d.png) | ![image](https://user-images.githubusercontent.com/246473/196955188-b2fc43d6-b3c5-4ddd-b80d-63eccf96b97d.png) | ![image](https://user-images.githubusercontent.com/246473/196955504-e397a456-4fef-477c-8acc-164244af4d77.png)
![image](https://user-images.githubusercontent.com/246473/196955798-beed619d-1e20-4862-881b-fd4108b50558.png) | ![image](https://user-images.githubusercontent.com/246473/196955163-d40e2ab4-ab0c-43e6-ae25-66016e450713.png) | ![image](https://user-images.githubusercontent.com/246473/196955480-5761e456-eca9-49c6-9345-1ff9ed9238b0.png)




@gnosis/mobile-devs
