### PR TITLE
Disable whats new screen

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
@@ -408,7 +408,8 @@ class StartActivity : BaseActivity(), SafeOverviewNavigationHandler, AppStateLis
     }
 
     private fun showWhatsNew() {
-        navController.navigate(R.id.whatsNewDialog)
+        // Enable when send funds is ready
+        //navController.navigate(R.id.whatsNewDialog)
     }
 
     private fun navigateToShareSafeDialog() {


### PR DESCRIPTION
Handles #

Changes proposed in this pull request:
- Since we will most likely not have the sends funds feature in this release-> I disabled the What's new screen

@gnosis/mobile-devs
