### PR TITLE
add BLUETOOTH_SCAN permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.NFC" />
 
     <uses-permission android:name="android.permission.BLUETOOTH"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 


### PR DESCRIPTION
Handles #1795 

Changes proposed in this pull request:
- add BLUETOOTH_SCAN permission as per https://github.com/safe-global/safe-android/issues/1795#issuecomment-1326625501
-
-

@gnosis/mobile-devs
