### PR TITLE
Chain prefix: App settings item 

### DIFF
--- a/app/src/main/java/io/gnosis/safe/Tracker.kt
+++ b/app/src/main/java/io/gnosis/safe/Tracker.kt
@@ -293,6 +293,7 @@ enum class ScreenId(val value: String) {
     SETTINGS_APP_ADVANCED("screen_settings_app_advanced"),
     SETTINGS_APP_APPEARANCE("screen_settings_app_appearance"),
     SETTINGS_APP_FIAT("screen_settings_app_edit_fiat"),
+    SETTINGS_APP_CHAIN_PREFIX("screen_settings_app_chain_prefix"),
     SETTINGS_APP_PASSCODE("screen_settings_app_passcode"),
     SETTINGS_GET_IN_TOUCH("screen_settings_app_support"),
     SETTINGS_ABOUT_SAFE("screen_settings_app_about_safe"),

--- a/app/src/main/java/io/gnosis/safe/di/components/ViewComponent.kt
+++ b/app/src/main/java/io/gnosis/safe/di/components/ViewComponent.kt
@@ -120,6 +120,8 @@ interface ViewComponent {
 
     fun inject(fragment: AppSettingsFragment)
 
+    fun inject(fragment: ChainPrefixAppSettingsFragment)
+
     fun inject(fragment: GetInTouchFragment)
 
     fun inject(fragment: AboutSafeFragment)

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/AppSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/AppSettingsFragment.kt
@@ -48,6 +48,9 @@ class AppSettingsFragment : BaseViewBindingFragment<FragmentSettingsAppBinding>(
             fiat.setOnClickListener {
                 findNavController().navigate(SettingsFragmentDirections.actionSettingsFragmentToAppFiatFragment())
             }
+            chainPrefix.setOnClickListener {
+                //TODO: navigate to chain prefix settings screen
+            }
             intercom.setOnClickListener {
                 viewModel.openIntercomMessenger()
             }

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/AppSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/AppSettingsFragment.kt
@@ -49,7 +49,7 @@ class AppSettingsFragment : BaseViewBindingFragment<FragmentSettingsAppBinding>(
                 findNavController().navigate(SettingsFragmentDirections.actionSettingsFragmentToAppFiatFragment())
             }
             chainPrefix.setOnClickListener {
-                //TODO: navigate to chain prefix settings screen
+                findNavController().navigate(SettingsFragmentDirections.actionSettingsFragmentToChainPrefixAppSettingsFragment())
             }
             intercom.setOnClickListener {
                 viewModel.openIntercomMessenger()

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/ChainPrefixAppSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/ChainPrefixAppSettingsFragment.kt
@@ -1,0 +1,29 @@
+package io.gnosis.safe.ui.settings.app
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import io.gnosis.safe.ScreenId
+import io.gnosis.safe.databinding.FragmentSettingsAppChainPrefixBinding
+import io.gnosis.safe.di.components.ViewComponent
+import io.gnosis.safe.ui.base.fragment.BaseViewBindingFragment
+import java.math.BigInteger
+
+class ChainPrefixAppSettingsFragment : BaseViewBindingFragment<FragmentSettingsAppChainPrefixBinding>() {
+
+    override fun screenId() = ScreenId.SETTINGS_APP_CHAIN_PREFIX
+
+    override suspend fun chainId(): BigInteger? = null
+
+    override fun inject(component: ViewComponent) {
+        component.inject(this)
+    }
+
+    override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentSettingsAppChainPrefixBinding =
+        FragmentSettingsAppChainPrefixBinding.inflate(inflater, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+    }
+}

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/ChainPrefixAppSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/ChainPrefixAppSettingsFragment.kt
@@ -4,11 +4,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.navigation.Navigation
 import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentSettingsAppChainPrefixBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.ui.base.fragment.BaseViewBindingFragment
 import java.math.BigInteger
+import javax.inject.Inject
 
 class ChainPrefixAppSettingsFragment : BaseViewBindingFragment<FragmentSettingsAppChainPrefixBinding>() {
 
@@ -20,10 +22,26 @@ class ChainPrefixAppSettingsFragment : BaseViewBindingFragment<FragmentSettingsA
         component.inject(this)
     }
 
+    @Inject
+    lateinit var settingsHandler: SettingsHandler
+
     override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentSettingsAppChainPrefixBinding =
         FragmentSettingsAppChainPrefixBinding.inflate(inflater, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        with(binding) {
+            backButton.setOnClickListener {
+                Navigation.findNavController(it).navigateUp()
+            }
+            prefixPrepend.settingSwitch.isChecked = settingsHandler.chainPrefixPrepend
+            prefixPrepend.settingSwitch.setOnCheckedChangeListener { _, isChecked ->
+                settingsHandler.chainPrefixPrepend = isChecked
+            }
+            prefixCopy.settingSwitch.isChecked = settingsHandler.chainPrefixCopy
+            prefixCopy.settingSwitch.setOnCheckedChangeListener { _, isChecked ->
+                settingsHandler.chainPrefixCopy = isChecked
+            }
+        }
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/SettingsHandler.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/SettingsHandler.kt
@@ -217,10 +217,26 @@ class SettingsHandler @Inject constructor(
         }
 
     var chainPrefixQr: Boolean
-        get() = preferencesManager.prefs.getBoolean(KEY_CHAIN_PREFIX_QR, false)
+        get() = preferencesManager.prefs.getBoolean(KEY_CHAIN_PREFIX_QR, true)
         set(value) {
             preferencesManager.prefs.edit {
                 putBoolean(KEY_CHAIN_PREFIX_QR, value)
+            }
+        }
+
+    var chainPrefixPrepend: Boolean
+        get() = preferencesManager.prefs.getBoolean(KEY_CHAIN_PREFIX_PREPEND, true)
+        set(value) {
+            preferencesManager.prefs.edit {
+                putBoolean(KEY_CHAIN_PREFIX_PREPEND, value)
+            }
+        }
+
+    var chainPrefixCopy: Boolean
+        get() = preferencesManager.prefs.getBoolean(KEY_CHAIN_PREFIX_COPY, true)
+        set(value) {
+            preferencesManager.prefs.edit {
+                putBoolean(KEY_CHAIN_PREFIX_COPY, value)
             }
         }
 
@@ -243,6 +259,8 @@ class SettingsHandler @Inject constructor(
         internal const val KEY_SHOW_WHATS_NEW = "prefs.boolean.show_whats_new"
 
         internal const val KEY_CHAIN_PREFIX_QR = "prefs.boolean.chain_prefix_qr"
+        internal const val KEY_CHAIN_PREFIX_PREPEND = "prefs.boolean.chain_prefix_prepend"
+        internal const val KEY_CHAIN_PREFIX_COPY = "prefs.boolean.chain_prefix_copy"
 
         internal const val KEY_UPDATE_SHOWN_FOR_VERSION = "prefs.integer.update_shown_for_version"
         internal const val KEY_FIREBASE_NEWEST_VERSION = "newestVersion"

--- a/app/src/main/res/layout/fragment_settings_app.xml
+++ b/app/src/main/res/layout/fragment_settings_app.xml
@@ -48,6 +48,16 @@
                 app:setting_openable="true" />
 
             <io.gnosis.safe.ui.settings.view.SettingItem
+                android:id="@+id/chain_prefix"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/item_setting_openable_height"
+                android:layout_marginTop="@dimen/item_setting_margin"
+                android:background="@drawable/background_secondary_selectable"
+                app:setting_image="@drawable/ic_settings_chain_24dp"
+                app:setting_name="@string/settings_app_chain_prefix"
+                app:setting_openable="true" />
+
+            <io.gnosis.safe.ui.settings.view.SettingItem
                 android:id="@+id/appearance"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_openable_height"

--- a/app/src/main/res/layout/fragment_settings_app_chain_prefix.xml
+++ b/app/src/main/res/layout/fragment_settings_app_chain_prefix.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_settings_app_chain_prefix.xml
+++ b/app/src/main/res/layout/fragment_settings_app_chain_prefix.xml
@@ -1,6 +1,99 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/background_secondary">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/background_secondary"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <LinearLayout
+            android:id="@+id/toolbar_layout"
+            style="@style/Toolbar"
+            android:orientation="horizontal"
+            android:padding="16dp"
+            app:elevation="4dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageButton
+                android:id="@+id/back_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:background="@android:color/transparent"
+                android:src="@drawable/ic_baseline_arrow_back_24"
+                android:text="@string/back" />
+
+            <TextView
+                android:id="@+id/title"
+                style="@style/ToolbarTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:text="@string/settings_app_chain_prefix" />
+
+        </LinearLayout>
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/background_primary"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/appbar">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+
+            <io.gnosis.safe.ui.settings.view.SettingItem
+                android:id="@+id/prefix_prepend"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/item_setting_openable_height"
+                android:layout_marginTop="@dimen/item_setting_margin"
+                android:background="@drawable/background_secondary_selectable"
+                app:setting_name="@string/settings_chain_prefix_prepend"
+                app:setting_openable="false"
+                app:setting_has_switch="true" />
+
+            <TextView
+                style="@style/Helptext"
+                android:text="@string/settings_chain_prefix_prepend_hint"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <io.gnosis.safe.ui.settings.view.SettingItem
+                android:id="@+id/prefix_copy"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/item_setting_openable_height"
+                android:layout_marginTop="@dimen/item_setting_margin"
+                android:background="@drawable/background_secondary_selectable"
+                app:setting_name="@string/settings_chain_prefix_copy"
+                app:setting_openable="false"
+                app:setting_has_switch="true" />
+
+            <TextView
+                android:id="@+id/use_passcode_for"
+                style="@style/Helptext"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_chain_prefix_copy_hint" />
+
+        </LinearLayout>
+
+    </androidx.core.widget.NestedScrollView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/main_nav.xml
+++ b/app/src/main/res/navigation/main_nav.xml
@@ -640,6 +640,11 @@
             app:popUpTo="@id/settingsFragment" />
 
         <action
+            android:id="@+id/action_settingsFragment_to_chainPrefixAppSettingsFragment"
+            app:destination="@id/chainPrefixAppSettingsFragment"
+            app:popUpTo="@id/settingsFragment" />
+
+        <action
             android:id="@+id/action_settingsFragment_to_nightModeSettingsFragment"
             app:destination="@id/nightModeAppSettingsFragment"
             app:popUpTo="@id/settingsFragment" />
@@ -672,6 +677,12 @@
         android:name="io.gnosis.safe.ui.settings.safe.SafeSettingsEditNameFragment"
         android:label="SafeSettingsEditNameFragment"
         tools:layout="@layout/fragment_settings_safe_edit_name" />
+
+    <fragment
+        android:id="@+id/chainPrefixAppSettingsFragment"
+        android:name="io.gnosis.safe.ui.settings.app.ChainPrefixAppSettingsFragment"
+        android:label="ChainPrefixAppSettingsFragment"
+        tools:layout="@layout/fragment_settings_app_chain_prefix" />
 
     <fragment
         android:id="@+id/aboutSafeFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -210,6 +210,7 @@
     <string name="settings_app_header_about">ABOUT</string>
 
     <string name="settings_app_chain_prefix_qr">QR code with chain prefix</string>
+    <string name="settings_app_chain_prefix">Chain prefix</string>
 
     <string name="settings_passcode_use_passcode">Use passcode</string>
     <string name="settings_passcode_change_passcode">Change passcode</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -211,6 +211,10 @@
 
     <string name="settings_app_chain_prefix_qr">QR code with chain prefix</string>
     <string name="settings_app_chain_prefix">Chain prefix</string>
+    <string name="settings_chain_prefix_prepend">Prepend adresses with chain prefix</string>
+    <string name="settings_chain_prefix_prepend_hint">When enabled, all chain-specific addresses will have the chain prefix displayed before them according to standard EIP-3770</string>
+    <string name="settings_chain_prefix_copy">Copy addresses with chain prefix</string>
+    <string name="settings_chain_prefix_copy_hint">When you copy any address, the app will prepend the chain according to standard EIP-3770</string>
 
     <string name="settings_passcode_use_passcode">Use passcode</string>
     <string name="settings_passcode_change_passcode">Change passcode</string>


### PR DESCRIPTION
Handles #1919

Changes proposed in this pull request:
- Chain prefix app settings screen
- UI only

<table>
<tr>
<td>
<img width="200" alt="Screenshot 2023-06-01 at 07 56 35" src="https://github.com/safe-global/safe-android/assets/17750984/4834fbed-a7c1-409c-91e0-0c6792386c96">
</td>
<td>
<img width="200" alt="Screenshot 2023-06-01 at 07 57 46" src="https://github.com/safe-global/safe-android/assets/17750984/b13bc1eb-3e42-4d66-a66a-ccf063b52ed7">
</td>
<td>
<img width="200" alt="Screenshot 2023-06-01 at 07 58 15" src="https://github.com/safe-global/safe-android/assets/17750984/20dc3d40-8c80-4aa6-9b04-d2daebc37797">
</td>
</tr>
</table>


@gnosis/mobile-devs
