### PR TITLE
Monitor transaction submitted for execution

### DIFF
--- a/app/src/main/java/io/gnosis/safe/di/modules/DatabaseModule.kt
+++ b/app/src/main/java/io/gnosis/safe/di/modules/DatabaseModule.kt
@@ -13,9 +13,11 @@ import io.gnosis.data.db.HeimdallDatabase.Companion.MIGRATION_5_6
 import io.gnosis.data.db.HeimdallDatabase.Companion.MIGRATION_6_7
 import io.gnosis.data.db.HeimdallDatabase.Companion.MIGRATION_7_8
 import io.gnosis.data.db.HeimdallDatabase.Companion.MIGRATION_8_9
+import io.gnosis.data.db.HeimdallDatabase.Companion.MIGRATION_9_10
 import io.gnosis.data.db.daos.ChainDao
 import io.gnosis.data.db.daos.OwnerDao
 import io.gnosis.data.db.daos.SafeDao
+import io.gnosis.data.db.daos.TransactionLocalDao
 import io.gnosis.safe.di.ApplicationContext
 import javax.inject.Singleton
 
@@ -34,7 +36,8 @@ class DatabaseModule {
                 MIGRATION_5_6,
                 MIGRATION_6_7,
                 MIGRATION_7_8,
-                MIGRATION_8_9
+                MIGRATION_8_9,
+                MIGRATION_9_10
             )
             .build()
 
@@ -49,4 +52,8 @@ class DatabaseModule {
     @Provides
     @Singleton
     fun providesChainDao(heimdallDatabase: HeimdallDatabase): ChainDao = heimdallDatabase.chainDao()
+
+    @Provides
+    @Singleton
+    fun providesTransactionLocalDao(heimdallDatabase: HeimdallDatabase): TransactionLocalDao = heimdallDatabase.transactionLocalDao()
 }

--- a/app/src/main/java/io/gnosis/safe/di/modules/RepositoryModule.kt
+++ b/app/src/main/java/io/gnosis/safe/di/modules/RepositoryModule.kt
@@ -7,6 +7,7 @@ import io.gnosis.data.backend.GatewayApi
 import io.gnosis.data.backend.rpc.RpcClient
 import io.gnosis.data.db.daos.ChainDao
 import io.gnosis.data.db.daos.SafeDao
+import io.gnosis.data.db.daos.TransactionLocalDao
 import io.gnosis.data.repositories.*
 import io.gnosis.safe.BuildConfig
 import io.gnosis.safe.workers.WorkRepository
@@ -74,6 +75,11 @@ class RepositoryModule {
     @Singleton
     fun providesTransactionRepository(gatewayApi: GatewayApi): TransactionRepository =
         TransactionRepository(gatewayApi)
+
+    @Provides
+    @Singleton
+    fun providesTransactionLocalRepository(localTxDao: TransactionLocalDao, rpcClient: RpcClient): TransactionLocalRepository =
+        TransactionLocalRepository(localTxDao, rpcClient)
 
     @Provides
     @Singleton

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
@@ -10,17 +10,33 @@ import io.gnosis.data.models.AddressInfo
 import io.gnosis.data.models.Chain
 import io.gnosis.data.models.Owner
 import io.gnosis.data.models.Safe
-import io.gnosis.data.models.transaction.*
+import io.gnosis.data.models.TransactionLocal
+import io.gnosis.data.models.transaction.ConflictType
+import io.gnosis.data.models.transaction.SafeAppInfo
+import io.gnosis.data.models.transaction.Transaction
+import io.gnosis.data.models.transaction.TransactionDirection
+import io.gnosis.data.models.transaction.TransactionInfo
+import io.gnosis.data.models.transaction.TransactionStatus
+import io.gnosis.data.models.transaction.TransferInfo
+import io.gnosis.data.models.transaction.TransferType
+import io.gnosis.data.models.transaction.TxListEntry
+import io.gnosis.data.models.transaction.decimals
+import io.gnosis.data.models.transaction.symbol
+import io.gnosis.data.models.transaction.value
 import io.gnosis.data.repositories.CredentialsRepository
 import io.gnosis.data.repositories.SafeRepository
+import io.gnosis.data.repositories.TransactionLocalRepository
 import io.gnosis.safe.R
 import io.gnosis.safe.ui.base.AppDispatchers
 import io.gnosis.safe.ui.base.BaseStateViewModel
 import io.gnosis.safe.ui.transactions.paging.TransactionPagingProvider
 import io.gnosis.safe.ui.transactions.paging.TransactionPagingSource
-import io.gnosis.safe.utils.*
+import io.gnosis.safe.utils.BalanceFormatter
+import io.gnosis.safe.utils.DEFAULT_ERC20_SYMBOL
+import io.gnosis.safe.utils.DEFAULT_ERC721_SYMBOL
+import io.gnosis.safe.utils.formatBackendDateTime
+import io.gnosis.safe.utils.formatBackendTimeOfDay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
 import pm.gnosis.utils.asEthereumAddressString
@@ -30,6 +46,7 @@ import javax.inject.Inject
 class TransactionListViewModel
 @Inject constructor(
     private val transactionsPager: TransactionPagingProvider,
+    private val transactionLocalRepository: TransactionLocalRepository,
     private val safeRepository: SafeRepository,
     private val credentialsRepository: CredentialsRepository,
     private val balanceFormatter: BalanceFormatter,
@@ -66,12 +83,17 @@ class TransactionListViewModel
         }
     }
 
-    private fun getTransactions(
+    private suspend fun getTransactions(
         safe: Safe,
         safes: List<Safe>,
         owners: List<Owner>,
         type: TransactionPagingSource.Type
     ): Flow<PagingData<TransactionView>> {
+
+        var txLocal: TransactionLocal? = null
+        if (type == TransactionPagingSource.Type.QUEUE ) {
+            txLocal = transactionLocalRepository.updateLocalTxLatest(safe)
+        }
 
         val safeTxItems: Flow<PagingData<TransactionView>> = transactionsPager.getTransactionsStream(safe, type)
             .map { pagingData ->
@@ -79,24 +101,51 @@ class TransactionListViewModel
                     .map { txListEntry ->
                         when (txListEntry) {
                             is TxListEntry.Transaction -> {
-                                val isConflict = txListEntry.conflictType != ConflictType.None
-                                val txView =
-                                    getTransactionView(
-                                        chain = safe.chain,
-                                        transaction = txListEntry.transaction,
-                                        safes = safes,
-                                        needsYourConfirmation = txListEntry.transaction.canBeSignedByAnyOwner(owners),
-                                        isConflict = isConflict,
-                                        localOwners = owners
-                                    )
-                                if (isConflict) {
-                                    TransactionView.Conflict(txView, txListEntry.conflictType)
-                                } else txView
+                                // conflict is resolved if there is local tx with same nonce
+                                // that was submitted for execution
+                                if (txLocal?.safeTxNonce == txListEntry.transaction.executionInfo?.nonce) {
+                                    if (txLocal?.safeTxHash == txListEntry.transaction.id.split("_").last() && txListEntry.transaction.txStatus == TransactionStatus.AWAITING_EXECUTION) {
+                                        val tx = txListEntry.transaction.copy(txStatus = TransactionStatus.PENDING)
+                                        txListEntry.transaction
+                                        getTransactionView(
+                                            chain = safe.chain,
+                                            transaction = tx,
+                                            safes = safes,
+                                            needsYourConfirmation = false,
+                                            isConflict = false,
+                                            localOwners = owners
+                                        )
+                                    } else {
+                                        TransactionView.Unknown
+                                    }
+                                } else {
+                                    val isConflict = txListEntry.conflictType != ConflictType.None
+                                    val txView =
+                                        getTransactionView(
+                                            chain = safe.chain,
+                                            transaction = txListEntry.transaction,
+                                            safes = safes,
+                                            needsYourConfirmation = txListEntry.transaction.canBeSignedByAnyOwner(owners),
+                                            isConflict = isConflict,
+                                            localOwners = owners
+                                        )
+                                    if (isConflict) {
+                                        TransactionView.Conflict(txView, txListEntry.conflictType)
+                                    } else txView
+                                }
                             }
                             is TxListEntry.DateLabel -> TransactionView.SectionDateHeader(date = txListEntry.timestamp)
                             is TxListEntry.Label -> TransactionView.SectionLabelHeader(label = txListEntry.label)
-                            is TxListEntry.ConflictHeader -> TransactionView.SectionConflictHeader(nonce = txListEntry.nonce)
-                            TxListEntry.Unknown -> TransactionView.Unknown
+                            is TxListEntry.ConflictHeader -> {
+                                // conflict is resolved if there is local tx with same nonce
+                                // that was submitted for execution
+                                if (txLocal?.safeTxNonce == txListEntry.nonce.toBigInteger()) {
+                                    TransactionView.Unknown
+                                } else {
+                                    TransactionView.SectionConflictHeader(nonce = txListEntry.nonce)
+                                }
+                            }
+                            else -> TransactionView.Unknown
                         }
                     }
                     .filter { it !is TransactionView.Unknown }

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
@@ -104,7 +104,8 @@ class TransactionListViewModel
                                 // conflict is resolved if there is local tx with same nonce
                                 // that was submitted for execution
                                 if (txLocal?.safeTxNonce == txListEntry.transaction.executionInfo?.nonce) {
-                                    if (txLocal?.safeTxHash == txListEntry.transaction.id.split("_").last() && txListEntry.transaction.txStatus == TransactionStatus.AWAITING_EXECUTION) {
+                                    // use submittedAt timestamp to distinguish between conflicting transactions
+                                    if (txLocal?.submittedAt == txListEntry.transaction.timestamp.time && txListEntry.transaction.txStatus == TransactionStatus.AWAITING_EXECUTION) {
                                         val tx = txListEntry.transaction.copy(txStatus = TransactionStatus.PENDING)
                                         txListEntry.transaction
                                         getTransactionView(

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
@@ -98,7 +98,7 @@ class TransactionListViewModel
             .map { pagingData ->
                 pagingData
                     .map { txListEntry ->
-                       mapTxListEntry(txListEntry, safe, safes, owners, type, txLocal)
+                       mapTxListEntry(txListEntry, safe, safes, owners, txLocal)
                     }
                     .filter { it !is TransactionView.Unknown }
             }
@@ -113,7 +113,6 @@ class TransactionListViewModel
         safe: Safe,
         safes: List<Safe>,
         owners: List<Owner>,
-        type: TransactionPagingSource.Type,
         txLocal: TransactionLocal? = null
     ): TransactionView {
         return when (txListEntry) {

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsViewModel.kt
@@ -277,9 +277,6 @@ class TransactionDetailsViewModel
                 val canExecute = canBeExecutedFromDevice(newExecutionInfo, owners)
                 val safeOwner = isOwner(newExecutionInfo, owners)
 
-////                 reload details
-//                loadDetails(newExecutionInfo.safeTxHash)
-
                 updateState {
                     TransactionDetailsViewState(
                         ConfirmationSubmitted(

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/viewdata/TransactionDetailsViewData.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/viewdata/TransactionDetailsViewData.kt
@@ -2,13 +2,24 @@ package io.gnosis.safe.ui.transactions.details.viewdata
 
 import android.os.Parcelable
 import androidx.annotation.VisibleForTesting
+import io.gnosis.data.adapters.SolidityAddressNullableParceler
+import io.gnosis.data.adapters.SolidityAddressParceler
 import io.gnosis.data.models.AddressInfo
 import io.gnosis.data.models.Owner
 import io.gnosis.data.models.Safe
-import io.gnosis.data.models.transaction.*
+import io.gnosis.data.models.transaction.DataDecoded
+import io.gnosis.data.models.transaction.DetailedExecutionInfo
+import io.gnosis.data.models.transaction.SafeAppInfo
+import io.gnosis.data.models.transaction.SettingsInfo
+import io.gnosis.data.models.transaction.SettingsInfoType
+import io.gnosis.data.models.transaction.TransactionDetails
+import io.gnosis.data.models.transaction.TransactionDirection
+import io.gnosis.data.models.transaction.TransactionInfo
+import io.gnosis.data.models.transaction.TransactionStatus
+import io.gnosis.data.models.transaction.TransactionType
+import io.gnosis.data.models.transaction.TransferInfo
+import io.gnosis.data.models.transaction.TxData
 import io.gnosis.safe.ui.transactions.AddressInfoData
-import io.gnosis.data.adapters.SolidityAddressNullableParceler
-import io.gnosis.data.adapters.SolidityAddressParceler
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.TypeParceler
@@ -16,7 +27,7 @@ import pm.gnosis.crypto.utils.asEthereumAddressChecksumString
 import pm.gnosis.model.Solidity
 import pm.gnosis.utils.asEthereumAddressString
 import java.math.BigInteger
-import java.util.*
+import java.util.Date
 
 @Parcelize
 data class TransactionDetailsViewData(

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/execution/TxReviewViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/execution/TxReviewViewModel.kt
@@ -8,6 +8,7 @@ import io.gnosis.data.models.Safe
 import io.gnosis.data.models.transaction.DetailedExecutionInfo
 import io.gnosis.data.models.transaction.TxData
 import io.gnosis.data.repositories.CredentialsRepository
+import io.gnosis.data.repositories.TransactionLocalRepository
 import io.gnosis.data.repositories.SafeRepository
 import io.gnosis.data.utils.toSignature
 import io.gnosis.safe.Tracker
@@ -36,6 +37,7 @@ class TxReviewViewModel
 @Inject constructor(
     private val safeRepository: SafeRepository,
     private val credentialsRepository: CredentialsRepository,
+    private val localTxRepository: TransactionLocalRepository,
     private val settingsHandler: SettingsHandler,
     private val rpcClient: RpcClient,
     private val balanceFormatter: BalanceFormatter,
@@ -453,7 +455,13 @@ class TxReviewViewModel
         safeLaunch {
             ethTxSignature?.let {
                 kotlin.runCatching {
-                    rpcClient.send(ethTx!!, it)
+                    val txHash = rpcClient.send(ethTx!!, it)
+                    localTxRepository.saveLocally(
+                        tx = ethTx!!,
+                        txHash = txHash,
+                        safeTxHash = (executionInfo as DetailedExecutionInfo.MultisigExecutionDetails).safeTxHash,
+                        safeTxNonce = (executionInfo as DetailedExecutionInfo.MultisigExecutionDetails).nonce
+                    )
                 }.onSuccess {
                     updateState {
                         TxReviewState(

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/execution/TxReviewViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/execution/TxReviewViewModel.kt
@@ -455,14 +455,16 @@ class TxReviewViewModel
         safeLaunch {
             ethTxSignature?.let {
                 kotlin.runCatching {
-                    val txHash = rpcClient.send(ethTx!!, it)
+                    rpcClient.send(ethTx!!, it)
+                }.onSuccess {
+                    val executionInfo = executionInfo as DetailedExecutionInfo.MultisigExecutionDetails
                     localTxRepository.saveLocally(
                         tx = ethTx!!,
-                        txHash = txHash,
-                        safeTxHash = (executionInfo as DetailedExecutionInfo.MultisigExecutionDetails).safeTxHash,
-                        safeTxNonce = (executionInfo as DetailedExecutionInfo.MultisigExecutionDetails).nonce
+                        txHash = it,
+                        safeTxHash = executionInfo.safeTxHash,
+                        safeTxNonce = executionInfo.nonce,
+                        submittedAt = executionInfo.submittedAt.time
                     )
-                }.onSuccess {
                     updateState {
                         TxReviewState(
                             viewAction =

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/execution/TxReviewViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/execution/TxReviewViewModel.kt
@@ -457,6 +457,7 @@ class TxReviewViewModel
                 kotlin.runCatching {
                     rpcClient.send(ethTx!!, it)
                 }.onSuccess {
+                    tracker.logTxExecSubmitted()
                     val executionInfo = executionInfo as DetailedExecutionInfo.MultisigExecutionDetails
                     localTxRepository.saveLocally(
                         tx = ethTx!!,

--- a/app/src/test/java/io/gnosis/safe/ui/transactions/TransactionListViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transactions/TransactionListViewModelTest.kt
@@ -260,24 +260,24 @@ class TransactionListViewModelTest {
             listOf(safe),
             listOf()
         )
-
-        assertEquals(TransactionView.TransferQueued(
-            "",
-            AWAITING_EXECUTION,
-            Chain.DEFAULT_CHAIN,
-            R.string.tx_status_needs_execution,
-            R.color.warning,
-            "< -0.00001 ETH",
-            transfer.timestamp,
-            R.drawable.ic_arrow_red_10dp,
-            R.string.tx_list_send,
-            R.color.label_primary,
-            1,
-            1,
-            R.color.success,
-            R.drawable.ic_confirmations_green_16dp,
-            "1"
-        ), transactionView)
+//FIXME: test runs locally but fails on CI
+//        assertEquals(TransactionView.TransferQueued(
+//            "",
+//            AWAITING_EXECUTION,
+//            Chain.DEFAULT_CHAIN,
+//            R.string.tx_status_needs_execution,
+//            R.color.warning,
+//            "< -0.00001 ETH",
+//            transfer.timestamp,
+//            R.drawable.ic_arrow_red_10dp,
+//            R.string.tx_list_send,
+//            R.color.label_primary,
+//            1,
+//            1,
+//            R.color.success,
+//            R.drawable.ic_confirmations_green_16dp,
+//            "1"
+//        ), transactionView)
     }
 
     @Test
@@ -307,24 +307,24 @@ class TransactionListViewModelTest {
                 0
             )
         )
-
-        assertEquals(TransactionView.TransferQueued(
-            "",
-            PENDING,
-            Chain.DEFAULT_CHAIN,
-            R.string.tx_status_pending,
-            R.color.warning,
-            "< -0.00001 ETH",
-            transfer.timestamp,
-            R.drawable.ic_arrow_red_10dp,
-            R.string.tx_list_send,
-            R.color.label_primary,
-            1,
-            1,
-            R.color.success,
-            R.drawable.ic_confirmations_green_16dp,
-            "1"
-        ), transactionView)
+//FIXME: test runs locally but fails on CI
+//        assertEquals(TransactionView.TransferQueued(
+//            "",
+//            PENDING,
+//            Chain.DEFAULT_CHAIN,
+//            R.string.tx_status_pending,
+//            R.color.warning,
+//            "< -0.00001 ETH",
+//            transfer.timestamp,
+//            R.drawable.ic_arrow_red_10dp,
+//            R.string.tx_list_send,
+//            R.color.label_primary,
+//            1,
+//            1,
+//            R.color.success,
+//            R.drawable.ic_confirmations_green_16dp,
+//            "1"
+//        ), transactionView)
     }
 
     @Test

--- a/app/src/test/java/io/gnosis/safe/ui/transactions/TransactionListViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transactions/TransactionListViewModelTest.kt
@@ -254,7 +254,12 @@ class TransactionListViewModelTest {
         transactionListViewModel =
             TransactionListViewModel(transactionPagingProvider, transactionLocalRepository, safeRepository, credentialsRepository, balanceFormatter, appDispatchers)
 
-        val transactionView = transactionListViewModel.mapTxListEntry(txListEnry, safe, listOf(safe), listOf())
+        val transactionView = transactionListViewModel.mapTxListEntry(
+            txListEnry,
+            safe,
+            listOf(safe),
+            listOf()
+        )
 
         assertEquals(TransactionView.TransferQueued(
             "",
@@ -263,7 +268,7 @@ class TransactionListViewModelTest {
             R.string.tx_status_needs_execution,
             R.color.warning,
             "< -0.00001 ETH",
-            Date(0),
+            transfer.timestamp,
             R.drawable.ic_arrow_red_10dp,
             R.string.tx_list_send,
             R.color.label_primary,
@@ -310,7 +315,7 @@ class TransactionListViewModelTest {
             R.string.tx_status_pending,
             R.color.warning,
             "< -0.00001 ETH",
-            Date(0),
+            transfer.timestamp,
             R.drawable.ic_arrow_red_10dp,
             R.string.tx_list_send,
             R.color.label_primary,

--- a/app/src/test/java/io/gnosis/safe/ui/transactions/TransactionListViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transactions/TransactionListViewModelTest.kt
@@ -260,24 +260,24 @@ class TransactionListViewModelTest {
             listOf(safe),
             listOf()
         )
-//FIXME: test runs locally but fails on CI
-//        assertEquals(TransactionView.TransferQueued(
-//            "",
-//            AWAITING_EXECUTION,
-//            Chain.DEFAULT_CHAIN,
-//            R.string.tx_status_needs_execution,
-//            R.color.warning,
-//            "< -0.00001 ETH",
-//            transfer.timestamp,
-//            R.drawable.ic_arrow_red_10dp,
-//            R.string.tx_list_send,
-//            R.color.label_primary,
-//            1,
-//            1,
-//            R.color.success,
-//            R.drawable.ic_confirmations_green_16dp,
-//            "1"
-//        ), transactionView)
+
+        assertEquals(TransactionView.TransferQueued(
+            "",
+            AWAITING_EXECUTION,
+            Chain.DEFAULT_CHAIN,
+            R.string.tx_status_needs_execution,
+            R.color.warning,
+            "< -0${DS}00001 ETH",
+            transfer.timestamp,
+            R.drawable.ic_arrow_red_10dp,
+            R.string.tx_list_send,
+            R.color.label_primary,
+            1,
+            1,
+            R.color.success,
+            R.drawable.ic_confirmations_green_16dp,
+            "1"
+        ), transactionView)
     }
 
     @Test
@@ -307,24 +307,24 @@ class TransactionListViewModelTest {
                 0
             )
         )
-//FIXME: test runs locally but fails on CI
-//        assertEquals(TransactionView.TransferQueued(
-//            "",
-//            PENDING,
-//            Chain.DEFAULT_CHAIN,
-//            R.string.tx_status_pending,
-//            R.color.warning,
-//            "< -0.00001 ETH",
-//            transfer.timestamp,
-//            R.drawable.ic_arrow_red_10dp,
-//            R.string.tx_list_send,
-//            R.color.label_primary,
-//            1,
-//            1,
-//            R.color.success,
-//            R.drawable.ic_confirmations_green_16dp,
-//            "1"
-//        ), transactionView)
+
+        assertEquals(TransactionView.TransferQueued(
+            "",
+            PENDING,
+            Chain.DEFAULT_CHAIN,
+            R.string.tx_status_pending,
+            R.color.warning,
+            "< -0${DS}00001 ETH",
+            transfer.timestamp,
+            R.drawable.ic_arrow_red_10dp,
+            R.string.tx_list_send,
+            R.color.label_primary,
+            1,
+            1,
+            R.color.success,
+            R.drawable.ic_confirmations_green_16dp,
+            "1"
+        ), transactionView)
     }
 
     @Test

--- a/app/src/test/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsViewModelTest.kt
@@ -120,6 +120,7 @@ class TransactionDetailsViewModelTest {
                 any()
             )
         } returns transactionDetails
+        coEvery { transactionLocalRepository.updateLocalTx(any(), any<String>()) } returns null
         coEvery { safeRepository.getSafes() } returns emptyList()
         coEvery { credentialsRepository.owners() } returns listOf()
         coEvery { safeRepository.getActiveSafe() } returns Safe(someAddress, "safe_name", CHAIN_ID)

--- a/app/src/test/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsViewModelTest.kt
@@ -172,6 +172,7 @@ class TransactionDetailsViewModelTest {
                 CHAIN_ID,
                 "tx_details_id"
             )
+            transactionLocalRepository.updateLocalTx(any(), any<String>())
         }
     }
 

--- a/app/src/test/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsViewModelTest.kt
@@ -14,12 +14,22 @@ import io.gnosis.data.models.transaction.TransactionDetails
 import io.gnosis.data.models.transaction.TransactionStatus
 import io.gnosis.data.repositories.CredentialsRepository
 import io.gnosis.data.repositories.SafeRepository
+import io.gnosis.data.repositories.TransactionLocalRepository
 import io.gnosis.data.repositories.TransactionRepository
-import io.gnosis.safe.*
+import io.gnosis.safe.TestLifecycleRule
+import io.gnosis.safe.TestLiveDataObserver
+import io.gnosis.safe.Tracker
+import io.gnosis.safe.appDispatchers
+import io.gnosis.safe.readJsonFrom
+import io.gnosis.safe.test
 import io.gnosis.safe.ui.base.BaseStateViewModel
 import io.gnosis.safe.ui.settings.app.SettingsHandler
 import io.gnosis.safe.ui.transactions.details.viewdata.toTransactionDetailsViewData
-import io.mockk.*
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -38,6 +48,7 @@ class TransactionDetailsViewModelTest {
     val instantExecutorRule = TestLifecycleRule()
 
     private val transactionRepository = mockk<TransactionRepository>()
+    private val transactionLocalRepository = mockk<TransactionLocalRepository>()
     private val safeRepository = mockk<SafeRepository>()
     private val credentialsRepository = mockk<CredentialsRepository>()
     private val settingsHandler = mockk<SettingsHandler>()
@@ -76,6 +87,7 @@ class TransactionDetailsViewModelTest {
 
             viewModel = TransactionDetailsViewModel(
                 transactionRepository,
+                transactionLocalRepository,
                 safeRepository,
                 credentialsRepository,
                 settingsHandler,
@@ -137,6 +149,7 @@ class TransactionDetailsViewModelTest {
 
         viewModel = TransactionDetailsViewModel(
             transactionRepository,
+            transactionLocalRepository,
             safeRepository,
             credentialsRepository,
             settingsHandler,
@@ -169,6 +182,7 @@ class TransactionDetailsViewModelTest {
 
             viewModel = TransactionDetailsViewModel(
                 transactionRepository,
+                transactionLocalRepository,
                 safeRepository,
                 credentialsRepository,
                 settingsHandler,
@@ -195,6 +209,7 @@ class TransactionDetailsViewModelTest {
 
             viewModel = TransactionDetailsViewModel(
                 transactionRepository,
+                transactionLocalRepository,
                 safeRepository,
                 credentialsRepository,
                 settingsHandler,
@@ -223,6 +238,7 @@ class TransactionDetailsViewModelTest {
 
             viewModel = TransactionDetailsViewModel(
                 transactionRepository,
+                transactionLocalRepository,
                 safeRepository,
                 credentialsRepository,
                 settingsHandler,
@@ -258,6 +274,7 @@ class TransactionDetailsViewModelTest {
 
             viewModel = TransactionDetailsViewModel(
                 transactionRepository,
+                transactionLocalRepository,
                 safeRepository,
                 credentialsRepository,
                 settingsHandler,
@@ -293,6 +310,7 @@ class TransactionDetailsViewModelTest {
 
             viewModel = TransactionDetailsViewModel(
                 transactionRepository,
+                transactionLocalRepository,
                 safeRepository,
                 credentialsRepository,
                 settingsHandler,
@@ -328,6 +346,7 @@ class TransactionDetailsViewModelTest {
 
             viewModel = TransactionDetailsViewModel(
                 transactionRepository,
+                transactionLocalRepository,
                 safeRepository,
                 credentialsRepository,
                 settingsHandler,
@@ -362,6 +381,7 @@ class TransactionDetailsViewModelTest {
 
             viewModel = TransactionDetailsViewModel(
                 transactionRepository,
+                transactionLocalRepository,
                 safeRepository,
                 credentialsRepository,
                 settingsHandler,
@@ -407,6 +427,7 @@ class TransactionDetailsViewModelTest {
 
             viewModel = TransactionDetailsViewModel(
                 transactionRepository,
+                transactionLocalRepository,
                 safeRepository,
                 credentialsRepository,
                 settingsHandler,
@@ -457,6 +478,7 @@ class TransactionDetailsViewModelTest {
 
             viewModel = TransactionDetailsViewModel(
                 transactionRepository,
+                transactionLocalRepository,
                 safeRepository,
                 credentialsRepository,
                 settingsHandler,
@@ -508,6 +530,7 @@ class TransactionDetailsViewModelTest {
 
             viewModel = TransactionDetailsViewModel(
                 transactionRepository,
+                transactionLocalRepository,
                 safeRepository,
                 credentialsRepository,
                 settingsHandler,
@@ -556,6 +579,7 @@ class TransactionDetailsViewModelTest {
 
             viewModel = TransactionDetailsViewModel(
                 transactionRepository,
+                transactionLocalRepository,
                 safeRepository,
                 credentialsRepository,
                 settingsHandler,

--- a/app/src/test/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsViewModelTest.kt
@@ -8,6 +8,7 @@ import io.gnosis.data.models.Chain
 import io.gnosis.data.models.Owner
 import io.gnosis.data.models.Safe
 import io.gnosis.data.models.SafeInfo
+import io.gnosis.data.models.TransactionLocal
 import io.gnosis.data.models.VersionState
 import io.gnosis.data.models.transaction.DetailedExecutionInfo
 import io.gnosis.data.models.transaction.TransactionDetails
@@ -147,6 +148,81 @@ class TransactionDetailsViewModelTest {
                 owners = emptyList(),
                 hasOwnerKey = false
             )
+
+        viewModel = TransactionDetailsViewModel(
+            transactionRepository,
+            transactionLocalRepository,
+            safeRepository,
+            credentialsRepository,
+            settingsHandler,
+            tracker,
+            appDispatchers
+        )
+
+        viewModel.loadDetails("tx_details_id")
+
+        with(viewModel.state.test().values()) {
+            assertEquals(
+                UpdateDetails(txDetails = expectedTransactionInfoViewData),
+                this[0].viewAction
+            )
+        }
+        coVerify(exactly = 1) {
+            transactionRepository.getTransactionDetails(
+                CHAIN_ID,
+                "tx_details_id"
+            )
+        }
+    }
+
+    @Test
+    fun `loadDetails (successful, awaiting execution with local pending tx) should emit txDetails with pending state`() = runTest(UnconfinedTestDispatcher()) {
+        val transactionDetailsDto = adapter.readJsonFrom("tx_details_transfer.json")
+        val transactionDetails = toTransactionDetails(transactionDetailsDto).copy(txStatus = TransactionStatus.AWAITING_EXECUTION)
+        val someAddress = "0x1230B3d59858296A31053C1b8562Ecf89A2f888b".asEthereumAddress()!!
+
+        coEvery {
+            transactionRepository.getTransactionDetails(
+                any(),
+                any()
+            )
+        } returns transactionDetails
+        coEvery { transactionLocalRepository.updateLocalTx(any(), any<String>()) } returns TransactionLocal(
+            CHAIN_ID,
+            Solidity.Address(BigInteger.ZERO),
+            BigInteger.ZERO,
+            (transactionDetails.detailedExecutionInfo as DetailedExecutionInfo.MultisigExecutionDetails).safeTxHash,
+            "",
+            TransactionStatus.PENDING,
+            0
+        )
+        coEvery { transactionLocalRepository.delete(any()) } just Runs
+        coEvery { safeRepository.getSafes() } returns emptyList()
+        coEvery { credentialsRepository.owners() } returns listOf()
+        coEvery { safeRepository.getActiveSafe() } returns Safe(someAddress, "safe_name", CHAIN_ID)
+        coEvery { safeRepository.getSafeInfo(any()) } returns SafeInfo(
+            AddressInfo(Solidity.Address(BigInteger.ONE)),
+            BigInteger.ONE,
+            1,
+            listOf(
+                AddressInfo(Solidity.Address(BigInteger.ONE))
+            ),
+            AddressInfo(Solidity.Address(BigInteger.ONE)),
+            listOf(AddressInfo(Solidity.Address(BigInteger.ONE))),
+            AddressInfo(Solidity.Address(BigInteger.ONE)),
+            null,
+            "1.1.1",
+            VersionState.OUTDATED
+        )
+        val expectedTransactionInfoViewData =
+            transactionDetails.toTransactionDetailsViewData(
+                emptyList(),
+                canSign = false,
+                canExecute = false,
+                nextInLine = false,
+                owners = emptyList(),
+                hasOwnerKey = false
+            ).copy(txStatus = TransactionStatus.PENDING)
 
         viewModel = TransactionDetailsViewModel(
             transactionRepository,

--- a/app/src/test/java/io/gnosis/safe/ui/transactions/execution/TxReviewViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transactions/execution/TxReviewViewModelTest.kt
@@ -25,6 +25,7 @@ import org.junit.Rule
 import org.junit.Test
 import pm.gnosis.model.Solidity
 import pm.gnosis.models.Wei
+import java.math.BigDecimal
 import java.math.BigInteger
 
 class TxReviewViewModelTest {
@@ -109,7 +110,7 @@ class TxReviewViewModelTest {
     }
 
     @Test
-    fun `updateDefaultKey(different address) emit DefaultKey and track key changed`() {
+    fun `updateDefaultKey(different address) should emit DefaultKey and track key changed`() {
         coEvery { safeRepository.getActiveSafe() } returns TEST_SAFE.apply {
             signingOwners = listOf(Solidity.Address(BigInteger.ONE), Solidity.Address(BigInteger.TEN))
         }
@@ -149,7 +150,7 @@ class TxReviewViewModelTest {
     }
 
     @Test
-    fun `updateDefaultKey(same address) emit DefaultKey and not track key changed`() {
+    fun `updateDefaultKey(same address) should emit DefaultKey and not track key changed`() {
         coEvery { safeRepository.getActiveSafe() } returns TEST_SAFE.apply {
             signingOwners = listOf(Solidity.Address(BigInteger.ONE), Solidity.Address(BigInteger.TEN))
         }
@@ -188,6 +189,35 @@ class TxReviewViewModelTest {
 
         coVerify(exactly = 0) {
             tracker.logTxExecKeyChanged()
+        }
+    }
+
+    @Test
+    fun `updateEstimationParams should emit UpdateFee`() {
+        coEvery { safeRepository.getActiveSafe() } returns TEST_SAFE.apply {
+            signingOwners = listOf(Solidity.Address(BigInteger.ONE), Solidity.Address(BigInteger.TEN))
+        }
+        coEvery { tracker.logTxExecFieldsEdit(any()) } just Runs
+
+        viewModel = TxReviewViewModel(
+            safeRepository,
+            credentialsRepository,
+            localTxRepository,
+            settingsHandler,
+            rpcClient,
+            balanceFormatter,
+            tracker,
+            appDispatchers
+        )
+
+        viewModel.updateEstimationParams(BigInteger.ZERO, BigInteger.ZERO, BigDecimal.ZERO, BigDecimal.ZERO)
+
+        with(viewModel.state.test().values()) {
+            Assert.assertEquals(
+                UpdateFee(
+                    "0 ${Chain.DEFAULT_CHAIN.currency.symbol}"
+                ), this[0].viewAction
+            )
         }
     }
 

--- a/app/src/test/java/io/gnosis/safe/ui/transactions/execution/TxReviewViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transactions/execution/TxReviewViewModelTest.kt
@@ -1,0 +1,213 @@
+package io.gnosis.safe.ui.transactions.execution
+
+import io.gnosis.data.backend.rpc.RpcClient
+import io.gnosis.data.models.Chain
+import io.gnosis.data.models.Owner
+import io.gnosis.data.models.Safe
+import io.gnosis.data.repositories.CredentialsRepository
+import io.gnosis.data.repositories.SafeRepository
+import io.gnosis.data.repositories.TransactionLocalRepository
+import io.gnosis.safe.TestLifecycleRule
+import io.gnosis.safe.Tracker
+import io.gnosis.safe.appDispatchers
+import io.gnosis.safe.test
+import io.gnosis.safe.ui.base.BaseStateViewModel
+import io.gnosis.safe.ui.settings.app.SettingsHandler
+import io.gnosis.safe.ui.settings.owner.list.OwnerViewData
+import io.gnosis.safe.utils.BalanceFormatter
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import pm.gnosis.model.Solidity
+import pm.gnosis.models.Wei
+import java.math.BigInteger
+
+class TxReviewViewModelTest {
+
+    @get:Rule
+    val instantExecutorRule = TestLifecycleRule()
+
+    private val safeRepository = mockk<SafeRepository>()
+    private val credentialsRepository = mockk<CredentialsRepository>()
+    private val localTxRepository = mockk<TransactionLocalRepository>()
+    private val settingsHandler = mockk<SettingsHandler>()
+    private val rpcClient = mockk<RpcClient>()
+    private val balanceFormatter = BalanceFormatter()
+    private val tracker = mockk<Tracker>()
+
+    private lateinit var viewModel: TxReviewViewModel
+
+    @Test
+    fun `loadDefaultKey() (success) should emit executionKey`() {
+        coEvery { safeRepository.getActiveSafe() } returns TEST_SAFE.apply {
+            signingOwners = listOf(Solidity.Address(BigInteger.ONE), Solidity.Address(BigInteger.TEN))
+        }
+        coEvery { credentialsRepository.owners() } returns listOf(TEST_SAFE_OWNER1)
+        coEvery { rpcClient.getBalances(any()) } returns listOf(Wei(BigInteger.TEN.pow(Chain.DEFAULT_CHAIN.currency.decimals)))
+
+        viewModel = TxReviewViewModel(
+            safeRepository,
+            credentialsRepository,
+            localTxRepository,
+            settingsHandler,
+            rpcClient,
+            balanceFormatter,
+            tracker,
+            appDispatchers
+        )
+
+        viewModel.loadDefaultKey()
+
+        with(viewModel.state.test().values()) {
+            Assert.assertEquals(
+                DefaultKey(
+                    OwnerViewData(
+                        TEST_SAFE_OWNER1.address,
+                        TEST_SAFE_OWNER1.name,
+                        Owner.Type.IMPORTED,
+                        "1 ${Chain.DEFAULT_CHAIN.currency.symbol}",
+                        false
+                    )
+                ), this[0].viewAction
+            )
+        }
+    }
+
+    @Test
+    fun `loadDefaultKey() (getBalances failure) should emit LoadBalancesFailed`() {
+        coEvery { safeRepository.getActiveSafe() } returns TEST_SAFE.apply {
+            signingOwners = listOf(Solidity.Address(BigInteger.ONE), Solidity.Address(BigInteger.TEN))
+        }
+        coEvery { credentialsRepository.owners() } returns listOf(TEST_SAFE_OWNER1)
+        coEvery { rpcClient.getBalances(any()) } throws Throwable()
+
+        viewModel = TxReviewViewModel(
+            safeRepository,
+            credentialsRepository,
+            localTxRepository,
+            settingsHandler,
+            rpcClient,
+            balanceFormatter,
+            tracker,
+            appDispatchers
+        )
+
+        viewModel.loadDefaultKey()
+
+        with(viewModel.state.test().values()) {
+            Assert.assertEquals(
+                BaseStateViewModel.ViewAction.ShowError(
+                    LoadBalancesFailed
+                ), this[0].viewAction
+            )
+        }
+    }
+
+    @Test
+    fun `updateDefaultKey(different address) emit DefaultKey and track key changed`() {
+        coEvery { safeRepository.getActiveSafe() } returns TEST_SAFE.apply {
+            signingOwners = listOf(Solidity.Address(BigInteger.ONE), Solidity.Address(BigInteger.TEN))
+        }
+        coEvery { credentialsRepository.owner(any()) } returns TEST_SAFE_OWNER1
+        coEvery { tracker.logTxExecKeyChanged() } just Runs
+
+        viewModel = TxReviewViewModel(
+            safeRepository,
+            credentialsRepository,
+            localTxRepository,
+            settingsHandler,
+            rpcClient,
+            balanceFormatter,
+            tracker,
+            appDispatchers
+        )
+
+        viewModel.updateDefaultKey(TEST_SAFE_OWNER2.address)
+
+        with(viewModel.state.test().values()) {
+            Assert.assertEquals(
+                DefaultKey(
+                    OwnerViewData(
+                        TEST_SAFE_OWNER1.address,
+                        TEST_SAFE_OWNER1.name,
+                        Owner.Type.IMPORTED,
+                        null,
+                        false
+                    )
+                ), this[0].viewAction
+            )
+        }
+
+        coVerify(exactly = 1) {
+           tracker.logTxExecKeyChanged()
+        }
+    }
+
+    @Test
+    fun `updateDefaultKey(same address) emit DefaultKey and not track key changed`() {
+        coEvery { safeRepository.getActiveSafe() } returns TEST_SAFE.apply {
+            signingOwners = listOf(Solidity.Address(BigInteger.ONE), Solidity.Address(BigInteger.TEN))
+        }
+        coEvery { credentialsRepository.owners() } returns listOf(TEST_SAFE_OWNER1)
+        coEvery { credentialsRepository.owner(any()) } returns TEST_SAFE_OWNER1
+        coEvery { rpcClient.getBalances(any()) } returns listOf(Wei(BigInteger.TEN.pow(Chain.DEFAULT_CHAIN.currency.decimals)))
+        coEvery { tracker.logTxExecKeyChanged() } just Runs
+
+        viewModel = TxReviewViewModel(
+            safeRepository,
+            credentialsRepository,
+            localTxRepository,
+            settingsHandler,
+            rpcClient,
+            balanceFormatter,
+            tracker,
+            appDispatchers
+        )
+
+        viewModel.loadDefaultKey()
+        viewModel.updateDefaultKey(TEST_SAFE_OWNER1.address)
+
+        with(viewModel.state.test().values()) {
+            Assert.assertEquals(
+                DefaultKey(
+                    OwnerViewData(
+                        TEST_SAFE_OWNER1.address,
+                        TEST_SAFE_OWNER1.name,
+                        Owner.Type.IMPORTED,
+                        null,
+                        false
+                    )
+                ), this[0].viewAction
+            )
+        }
+
+        coVerify(exactly = 0) {
+            tracker.logTxExecKeyChanged()
+        }
+    }
+
+    companion object {
+        val TEST_SAFE = Safe(
+            Solidity.Address(BigInteger.ZERO),
+            "safe_name",
+            Chain.DEFAULT_CHAIN.chainId
+        )
+
+        val TEST_SAFE_OWNER1 = Owner(
+            Solidity.Address(BigInteger.ONE),
+            "owner1",
+            Owner.Type.IMPORTED
+        )
+
+        val TEST_SAFE_OWNER2 = Owner(
+            Solidity.Address(BigInteger.TEN),
+            "owner2",
+            Owner.Type.IMPORTED
+        )
+    }
+}

--- a/buildsystem/versions.gradle
+++ b/buildsystem/versions.gradle
@@ -44,7 +44,7 @@ ext {
             play_services_auth              : '17.0.0',
             retrofit                        : '2.6.2',
             status_keycard                  : '3.0.1',
-            svalinn                         : 'fe7817a4d2',//''v0.16.0',
+            svalinn                         : 'v0.16.1',
             timber                          : '4.7.1',
             zxing                           : '3.3.1',
             play_core                       : '1.9.1',

--- a/data/schemas/io.gnosis.data.db.HeimdallDatabase/10.json
+++ b/data/schemas/io.gnosis.data.db.HeimdallDatabase/10.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 10,
-    "identityHash": "8c491039b43bd8018d232bb2c807bb49",
+    "identityHash": "2e9a1088f3438046177df042dfb4f0bd",
     "entities": [
       {
         "tableName": "safes",
@@ -243,7 +243,7 @@
       },
       {
         "tableName": "local_transactions",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chain_id` TEXT NOT NULL, `safe_address` TEXT NOT NULL, `safe_tx_nonce` TEXT NOT NULL, `safe_tx_hash` TEXT NOT NULL, `eth_tx_hash` TEXT NOT NULL, `status` TEXT NOT NULL, PRIMARY KEY(`chain_id`, `safe_address`, `safe_tx_hash`), FOREIGN KEY(`chain_id`, `safe_address`) REFERENCES `safes`(`chain_id`, `address`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chain_id` TEXT NOT NULL, `safe_address` TEXT NOT NULL, `safe_tx_nonce` TEXT NOT NULL, `safe_tx_hash` TEXT NOT NULL, `eth_tx_hash` TEXT NOT NULL, `status` TEXT NOT NULL, `submitted_at` INTEGER NOT NULL, PRIMARY KEY(`safe_address`, `chain_id`, `safe_tx_hash`))",
         "fields": [
           {
             "fieldPath": "chainId",
@@ -280,38 +280,30 @@
             "columnName": "status",
             "affinity": "TEXT",
             "notNull": true
+          },
+          {
+            "fieldPath": "submittedAt",
+            "columnName": "submitted_at",
+            "affinity": "INTEGER",
+            "notNull": true
           }
         ],
         "primaryKey": {
           "columnNames": [
-            "chain_id",
             "safe_address",
+            "chain_id",
             "safe_tx_hash"
           ],
           "autoGenerate": false
         },
         "indices": [],
-        "foreignKeys": [
-          {
-            "table": "safes",
-            "onDelete": "CASCADE",
-            "onUpdate": "CASCADE",
-            "columns": [
-              "chain_id",
-              "safe_address"
-            ],
-            "referencedColumns": [
-              "chain_id",
-              "address"
-            ]
-          }
-        ]
+        "foreignKeys": []
       }
     ],
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8c491039b43bd8018d232bb2c807bb49')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2e9a1088f3438046177df042dfb4f0bd')"
     ]
   }
 }

--- a/data/schemas/io.gnosis.data.db.HeimdallDatabase/10.json
+++ b/data/schemas/io.gnosis.data.db.HeimdallDatabase/10.json
@@ -1,0 +1,317 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "8c491039b43bd8018d232bb2c807bb49",
+    "entities": [
+      {
+        "tableName": "safes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`address` TEXT NOT NULL, `local_name` TEXT NOT NULL, `chain_id` TEXT NOT NULL, `version` TEXT, PRIMARY KEY(`address`, `chain_id`))",
+        "fields": [
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localName",
+            "columnName": "local_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chainId",
+            "columnName": "chain_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "address",
+            "chain_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "owners",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`address` TEXT NOT NULL, `name` TEXT, `type` INTEGER NOT NULL, `private_key` TEXT, `seed_phrase` TEXT, `derivation_path` TEXT, `source_fingerprint` TEXT, PRIMARY KEY(`address`))",
+        "fields": [
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "privateKey",
+            "columnName": "private_key",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "seedPhrase",
+            "columnName": "seed_phrase",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "keyDerivationPath",
+            "columnName": "derivation_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sourceFingerprint",
+            "columnName": "source_fingerprint",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "address"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "chains",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chain_id` TEXT NOT NULL, `l2` INTEGER NOT NULL, `chain_name` TEXT NOT NULL, `chain_short_name` TEXT NOT NULL, `text_color` TEXT NOT NULL, `background_color` TEXT NOT NULL, `rpc_uri` TEXT NOT NULL, `rpc_authentication` INTEGER NOT NULL, `block_explorer_address_uri` TEXT NOT NULL, `block_explorer_tx_hash_uri` TEXT NOT NULL, `ens_registry_address` TEXT, `features` TEXT NOT NULL, PRIMARY KEY(`chain_id`))",
+        "fields": [
+          {
+            "fieldPath": "chainId",
+            "columnName": "chain_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "l2",
+            "columnName": "l2",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "chain_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "chain_short_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textColor",
+            "columnName": "text_color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundColor",
+            "columnName": "background_color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rpcUri",
+            "columnName": "rpc_uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rpcAuthentication",
+            "columnName": "rpc_authentication",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "blockExplorerTemplateAddress",
+            "columnName": "block_explorer_address_uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "blockExplorerTemplateTxHash",
+            "columnName": "block_explorer_tx_hash_uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ensRegistryAddress",
+            "columnName": "ens_registry_address",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "features",
+            "columnName": "features",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "chain_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "native_currency",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chain_id` TEXT NOT NULL, `name` TEXT NOT NULL, `symbol` TEXT NOT NULL, `decimals` INTEGER NOT NULL, `logo_uri` TEXT NOT NULL, PRIMARY KEY(`chain_id`), FOREIGN KEY(`chain_id`) REFERENCES `chains`(`chain_id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "chainId",
+            "columnName": "chain_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "symbol",
+            "columnName": "symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "decimals",
+            "columnName": "decimals",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoUri",
+            "columnName": "logo_uri",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "chain_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "chains",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "chain_id"
+            ],
+            "referencedColumns": [
+              "chain_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chain_id` TEXT NOT NULL, `safe_address` TEXT NOT NULL, `safe_tx_nonce` TEXT NOT NULL, `safe_tx_hash` TEXT NOT NULL, `eth_tx_hash` TEXT NOT NULL, `status` TEXT NOT NULL, PRIMARY KEY(`chain_id`, `safe_address`, `safe_tx_hash`), FOREIGN KEY(`chain_id`, `safe_address`) REFERENCES `safes`(`chain_id`, `address`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "chainId",
+            "columnName": "chain_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "safeAddress",
+            "columnName": "safe_address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "safeTxNonce",
+            "columnName": "safe_tx_nonce",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "safeTxHash",
+            "columnName": "safe_tx_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ethTxHash",
+            "columnName": "eth_tx_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "chain_id",
+            "safe_address",
+            "safe_tx_hash"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "safes",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "chain_id",
+              "safe_address"
+            ],
+            "referencedColumns": [
+              "chain_id",
+              "address"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8c491039b43bd8018d232bb2c807bb49')"
+    ]
+  }
+}

--- a/data/src/androidTest/java/io/gnosis/data/db/HeimdallDatabaseTest.kt
+++ b/data/src/androidTest/java/io/gnosis/data/db/HeimdallDatabaseTest.kt
@@ -49,7 +49,8 @@ class HeimdallDatabaseTest {
             HeimdallDatabase.MIGRATION_5_6,
             HeimdallDatabase.MIGRATION_6_7,
             HeimdallDatabase.MIGRATION_7_8,
-            HeimdallDatabase.MIGRATION_8_9
+            HeimdallDatabase.MIGRATION_8_9,
+            HeimdallDatabase.MIGRATION_9_10
         )
 
         // Open latest version of the database. Room will validate the schema
@@ -242,6 +243,7 @@ class HeimdallDatabaseTest {
     fun migrate6To7() {
         val chain = Chain(
             Chain.ID_MAINNET,
+            false,
             "Mainnet",
             "eth",
             "",
@@ -250,7 +252,8 @@ class HeimdallDatabaseTest {
             RpcAuthentication.API_KEY_PATH,
             "",
             "",
-            null
+            null,
+            listOf()
         )
 
         helper.createDatabase(TEST_DB, 6).apply {

--- a/data/src/main/java/io/gnosis/data/db/HeimdallDatabase.kt
+++ b/data/src/main/java/io/gnosis/data/db/HeimdallDatabase.kt
@@ -144,7 +144,7 @@ abstract class HeimdallDatabase : RoomDatabase() {
         val MIGRATION_9_10 = object : Migration(9, 10) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL(
-                    """CREATE TABLE IF NOT EXISTS `${TransactionLocal.TABLE_NAME}` (`${TransactionLocal.COL_CHAIN_ID}` TEXT NOT NULL, `${TransactionLocal.COL_SAFE_ADDRESS}` TEXT NOT NULL, `${TransactionLocal.COL_SAFE_TX_NONCE}` TEXT NOT NULL, `${TransactionLocal.COL_SAFE_TX_HASH}` TEXT NOT NULL, `${TransactionLocal.COL_ETH_TX_HASH}` TEXT NOT NULL, `${TransactionLocal.COL_STATUS}` TEXT NOT NULL, PRIMARY KEY(`${TransactionLocal.COL_CHAIN_ID}`, `${TransactionLocal.COL_SAFE_ADDRESS}`, `${TransactionLocal.COL_SAFE_TX_HASH}`), FOREIGN KEY(`${TransactionLocal.COL_CHAIN_ID}`, `${TransactionLocal.COL_SAFE_ADDRESS}`) REFERENCES `${Safe.TABLE_NAME}`(`${Safe.COL_CHAIN_ID}`, `${Safe.COL_ADDRESS}`) ON UPDATE CASCADE ON DELETE CASCADE )"""
+                    """CREATE TABLE IF NOT EXISTS `${TransactionLocal.TABLE_NAME}` (`${TransactionLocal.COL_CHAIN_ID}` TEXT NOT NULL, `${TransactionLocal.COL_SAFE_ADDRESS}` TEXT NOT NULL, `${TransactionLocal.COL_SAFE_TX_NONCE}` TEXT NOT NULL, `${TransactionLocal.COL_SAFE_TX_HASH}` TEXT NOT NULL, `${TransactionLocal.COL_ETH_TX_HASH}` TEXT NOT NULL, `${TransactionLocal.COL_STATUS}` TEXT NOT NULL, `${TransactionLocal.COL_SUBMITTED_AT}` INTEGER NOT NULL, PRIMARY KEY(`${TransactionLocal.COL_SAFE_ADDRESS}`, `${TransactionLocal.COL_CHAIN_ID}`, `${TransactionLocal.COL_SAFE_TX_HASH}`))"""
                 )
             }
         }

--- a/data/src/main/java/io/gnosis/data/db/HeimdallDatabase.kt
+++ b/data/src/main/java/io/gnosis/data/db/HeimdallDatabase.kt
@@ -9,6 +9,7 @@ import io.gnosis.data.BuildConfig
 import io.gnosis.data.db.daos.ChainDao
 import io.gnosis.data.db.daos.OwnerDao
 import io.gnosis.data.db.daos.SafeDao
+import io.gnosis.data.db.daos.TransactionLocalDao
 import io.gnosis.data.models.*
 import pm.gnosis.svalinn.security.db.EncryptedByteArray
 import pm.gnosis.svalinn.security.db.EncryptedString
@@ -18,7 +19,8 @@ import pm.gnosis.svalinn.security.db.EncryptedString
         Safe::class,
         Owner::class,
         Chain::class,
-        Chain.Currency::class
+        Chain.Currency::class,
+        TransactionLocal::class
     ], version = HeimdallDatabase.LATEST_DB_VERSION
 )
 @TypeConverters(
@@ -38,9 +40,11 @@ abstract class HeimdallDatabase : RoomDatabase() {
 
     abstract fun chainDao(): ChainDao
 
+    abstract fun transactionLocalDao(): TransactionLocalDao
+
     companion object {
         const val DB_NAME = "safe_db"
-        const val LATEST_DB_VERSION = 9
+        const val LATEST_DB_VERSION = 10
 
         val MIGRATION_1_2 = object : Migration(1, 2) {
             override fun migrate(database: SupportSQLiteDatabase) {
@@ -133,6 +137,14 @@ abstract class HeimdallDatabase : RoomDatabase() {
                 )
                 database.execSQL(
                     """ALTER TABLE `${Chain.TABLE_NAME}` ADD COLUMN `${Chain.COL_FEATURES}` TEXT NOT NULL DEFAULT ''"""
+                )
+            }
+        }
+
+        val MIGRATION_9_10 = object : Migration(9, 10) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    """CREATE TABLE IF NOT EXISTS `${TransactionLocal.TABLE_NAME}` (`${TransactionLocal.COL_CHAIN_ID}` TEXT NOT NULL, `${TransactionLocal.COL_SAFE_ADDRESS}` TEXT NOT NULL, `${TransactionLocal.COL_SAFE_TX_NONCE}` TEXT NOT NULL, `${TransactionLocal.COL_SAFE_TX_HASH}` TEXT NOT NULL, `${TransactionLocal.COL_ETH_TX_HASH}` TEXT NOT NULL, `${TransactionLocal.COL_STATUS}` TEXT NOT NULL, PRIMARY KEY(`${TransactionLocal.COL_CHAIN_ID}`, `${TransactionLocal.COL_SAFE_ADDRESS}`, `${TransactionLocal.COL_SAFE_TX_HASH}`), FOREIGN KEY(`${TransactionLocal.COL_CHAIN_ID}`, `${TransactionLocal.COL_SAFE_ADDRESS}`) REFERENCES `${Safe.TABLE_NAME}`(`${Safe.COL_CHAIN_ID}`, `${Safe.COL_ADDRESS}`) ON UPDATE CASCADE ON DELETE CASCADE )"""
                 )
             }
         }

--- a/data/src/main/java/io/gnosis/data/db/daos/TransactionLocalDao.kt
+++ b/data/src/main/java/io/gnosis/data/db/daos/TransactionLocalDao.kt
@@ -17,12 +17,11 @@ interface TransactionLocalDao {
 
     @Delete
     suspend fun delete(tx: TransactionLocal)
-
-    @Query("DELETE FROM ${TransactionLocal.TABLE_NAME}")
-    abstract fun deleteAll()
+    @Query("DELETE FROM ${TransactionLocal.TABLE_NAME} WHERE ${TransactionLocal.COL_CHAIN_ID} = :chainId AND ${TransactionLocal.COL_SAFE_ADDRESS} = :safeAddress")
+    suspend fun clearOldRecords(chainId: BigInteger, safeAddress: Solidity.Address)
 
     @Query("SELECT * FROM ${TransactionLocal.TABLE_NAME} WHERE ${TransactionLocal.COL_CHAIN_ID} = :chainId AND ${TransactionLocal.COL_SAFE_ADDRESS} = :safeAddress AND ${TransactionLocal.COL_SAFE_TX_HASH} = :safeTxHash")
-    suspend fun loadyByEthTxHash(chainId: BigInteger, safeAddress: Solidity.Address, safeTxHash: String): TransactionLocal?
+    suspend fun loadyBySafeTxHash(chainId: BigInteger, safeAddress: Solidity.Address, safeTxHash: String): TransactionLocal?
 
     @Query("SELECT * FROM ${TransactionLocal.TABLE_NAME} WHERE ${TransactionLocal.COL_CHAIN_ID} = :chainId AND ${TransactionLocal.COL_SAFE_ADDRESS} = :safeAddress ORDER BY ${TransactionLocal.COL_SAFE_TX_NONCE} DESC LIMIT 1")
     suspend fun loadLatest(chainId: BigInteger, safeAddress: Solidity.Address): TransactionLocal?

--- a/data/src/main/java/io/gnosis/data/db/daos/TransactionLocalDao.kt
+++ b/data/src/main/java/io/gnosis/data/db/daos/TransactionLocalDao.kt
@@ -1,0 +1,29 @@
+package io.gnosis.data.db.daos
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import io.gnosis.data.models.TransactionLocal
+import pm.gnosis.model.Solidity
+import java.math.BigInteger
+
+@Dao
+interface TransactionLocalDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun save(tx: TransactionLocal)
+
+    @Delete
+    suspend fun delete(tx: TransactionLocal)
+
+    @Query("DELETE FROM ${TransactionLocal.TABLE_NAME}")
+    abstract fun deleteAll()
+
+    @Query("SELECT * FROM ${TransactionLocal.TABLE_NAME} WHERE ${TransactionLocal.COL_CHAIN_ID} = :chainId AND ${TransactionLocal.COL_SAFE_ADDRESS} = :safeAddress AND ${TransactionLocal.COL_SAFE_TX_HASH} = :safeTxHash")
+    suspend fun loadyByEthTxHash(chainId: BigInteger, safeAddress: Solidity.Address, safeTxHash: String): TransactionLocal?
+
+    @Query("SELECT * FROM ${TransactionLocal.TABLE_NAME} WHERE ${TransactionLocal.COL_CHAIN_ID} = :chainId AND ${TransactionLocal.COL_SAFE_ADDRESS} = :safeAddress ORDER BY ${TransactionLocal.COL_SAFE_TX_NONCE} DESC LIMIT 1")
+    suspend fun loadLatest(chainId: BigInteger, safeAddress: Solidity.Address): TransactionLocal?
+}

--- a/data/src/main/java/io/gnosis/data/db/daos/TransactionLocalDao.kt
+++ b/data/src/main/java/io/gnosis/data/db/daos/TransactionLocalDao.kt
@@ -17,6 +17,7 @@ interface TransactionLocalDao {
 
     @Delete
     suspend fun delete(tx: TransactionLocal)
+
     @Query("DELETE FROM ${TransactionLocal.TABLE_NAME} WHERE ${TransactionLocal.COL_CHAIN_ID} = :chainId AND ${TransactionLocal.COL_SAFE_ADDRESS} = :safeAddress")
     suspend fun clearOldRecords(chainId: BigInteger, safeAddress: Solidity.Address)
 

--- a/data/src/main/java/io/gnosis/data/models/TransactionLocal.kt
+++ b/data/src/main/java/io/gnosis/data/models/TransactionLocal.kt
@@ -2,7 +2,6 @@ package io.gnosis.data.models
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
-import androidx.room.ForeignKey
 import io.gnosis.data.models.TransactionLocal.Companion.COL_CHAIN_ID
 import io.gnosis.data.models.TransactionLocal.Companion.COL_SAFE_ADDRESS
 import io.gnosis.data.models.TransactionLocal.Companion.COL_SAFE_TX_HASH
@@ -13,16 +12,7 @@ import java.math.BigInteger
 
 @Entity(
     tableName = TABLE_NAME,
-    primaryKeys = [COL_CHAIN_ID, COL_SAFE_ADDRESS, COL_SAFE_TX_HASH],
-    foreignKeys = [
-        ForeignKey(
-            entity = Safe::class,
-            parentColumns = [Safe.COL_CHAIN_ID, Safe.COL_ADDRESS],
-            childColumns = [COL_CHAIN_ID, COL_SAFE_ADDRESS],
-            onUpdate = ForeignKey.CASCADE,
-            onDelete = ForeignKey.CASCADE
-        )
-    ]
+    primaryKeys = [COL_SAFE_ADDRESS, COL_CHAIN_ID, COL_SAFE_TX_HASH]
 )
 data class TransactionLocal(
 
@@ -42,16 +32,20 @@ data class TransactionLocal(
     val ethTxHash: String,
 
     @ColumnInfo(name = COL_STATUS)
-    val status: TransactionStatus
+    val status: TransactionStatus,
+
+    @ColumnInfo(name = COL_SUBMITTED_AT)
+    val submittedAt: Long,
 ) {
     companion object {
         const val TABLE_NAME = "local_transactions"
 
         const val COL_CHAIN_ID = "chain_id"
         const val COL_SAFE_ADDRESS = "safe_address"
-        const val COL_STATUS = "status"
-        const val COL_ETH_TX_HASH = "eth_tx_hash"
-        const val COL_SAFE_TX_HASH = "safe_tx_hash"
         const val COL_SAFE_TX_NONCE = "safe_tx_nonce"
+        const val COL_SAFE_TX_HASH = "safe_tx_hash"
+        const val COL_ETH_TX_HASH = "eth_tx_hash"
+        const val COL_STATUS = "status"
+        const val COL_SUBMITTED_AT = "submitted_at"
     }
 }

--- a/data/src/main/java/io/gnosis/data/models/TransactionLocal.kt
+++ b/data/src/main/java/io/gnosis/data/models/TransactionLocal.kt
@@ -1,0 +1,57 @@
+package io.gnosis.data.models
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import io.gnosis.data.models.TransactionLocal.Companion.COL_CHAIN_ID
+import io.gnosis.data.models.TransactionLocal.Companion.COL_SAFE_ADDRESS
+import io.gnosis.data.models.TransactionLocal.Companion.COL_SAFE_TX_HASH
+import io.gnosis.data.models.TransactionLocal.Companion.TABLE_NAME
+import io.gnosis.data.models.transaction.TransactionStatus
+import pm.gnosis.model.Solidity
+import java.math.BigInteger
+
+@Entity(
+    tableName = TABLE_NAME,
+    primaryKeys = [COL_CHAIN_ID, COL_SAFE_ADDRESS, COL_SAFE_TX_HASH],
+    foreignKeys = [
+        ForeignKey(
+            entity = Safe::class,
+            parentColumns = [Safe.COL_CHAIN_ID, Safe.COL_ADDRESS],
+            childColumns = [COL_CHAIN_ID, COL_SAFE_ADDRESS],
+            onUpdate = ForeignKey.CASCADE,
+            onDelete = ForeignKey.CASCADE
+        )
+    ]
+)
+data class TransactionLocal(
+
+    @ColumnInfo(name = COL_CHAIN_ID)
+    val chainId: BigInteger,
+
+    @ColumnInfo(name = COL_SAFE_ADDRESS)
+    val safeAddress: Solidity.Address,
+
+    @ColumnInfo(name = COL_SAFE_TX_NONCE)
+    val safeTxNonce: BigInteger,
+
+    @ColumnInfo(name = COL_SAFE_TX_HASH)
+    val safeTxHash: String,
+
+    @ColumnInfo(name = COL_ETH_TX_HASH)
+    val ethTxHash: String,
+
+    @ColumnInfo(name = COL_STATUS)
+    val status: TransactionStatus
+) {
+    companion object {
+        const val TABLE_NAME = "local_transactions"
+
+        const val COL_CHAIN_ID = "chain_id"
+        const val COL_SAFE_ADDRESS = "safe_address"
+        const val COL_STATUS = "status"
+        const val COL_ETH_TX_HASH = "eth_tx_hash"
+        const val COL_SAFE_TX_HASH = "safe_tx_hash"
+        const val COL_SAFE_TX_NONCE = "safe_tx_nonce"
+    }
+}

--- a/data/src/main/java/io/gnosis/data/repositories/TransactionLocalRepository.kt
+++ b/data/src/main/java/io/gnosis/data/repositories/TransactionLocalRepository.kt
@@ -1,0 +1,71 @@
+package io.gnosis.data.repositories
+
+import io.gnosis.data.backend.rpc.RpcClient
+import io.gnosis.data.db.daos.TransactionLocalDao
+import io.gnosis.data.models.Safe
+import io.gnosis.data.models.TransactionLocal
+import io.gnosis.data.models.transaction.TransactionStatus
+import pm.gnosis.models.Transaction
+import java.math.BigInteger
+
+class TransactionLocalRepository(
+    private val localTxDao: TransactionLocalDao,
+    private val rpcClient: RpcClient
+) {
+
+    suspend fun saveLocally(tx: Transaction, txHash: String, safeTxHash: String, safeTxNonce: BigInteger) {
+        // clean up old txs
+        // only latest tx submitted for execution is relevant
+        localTxDao.deleteAll()
+        val localTx = TransactionLocal(
+            safeAddress = tx.to,
+            chainId = tx.chainId,
+            safeTxNonce = safeTxNonce,
+            safeTxHash = safeTxHash,
+            ethTxHash = txHash,
+            status = TransactionStatus.PENDING
+        )
+        localTxDao.save(localTx)
+    }
+
+    suspend fun save(localTx: TransactionLocal) {
+        localTxDao.save(localTx)
+    }
+
+    suspend fun delete(localTx: TransactionLocal) {
+        localTxDao.delete(localTx)
+    }
+
+    suspend fun getLocalTx(safe: Safe, safeTxHash: String): TransactionLocal? =
+        localTxDao.loadyByEthTxHash(safe.chainId, safe.address, safeTxHash)
+
+    suspend fun getLocalTxLatest(safe: Safe): TransactionLocal? =
+        localTxDao.loadLatest(safe.chainId, safe.address)
+
+    suspend fun updateLocalTx(safe: Safe, safeTxHash: String): TransactionLocal? {
+        return getLocalTx(safe, safeTxHash)?.let {
+            updateLocalTx(safe, it)
+        }
+    }
+
+    suspend fun updateLocalTxLatest(safe: Safe): TransactionLocal? {
+        return getLocalTxLatest(safe)?.let {
+            updateLocalTx(safe, it)
+        }
+    }
+
+    suspend fun updateLocalTx(safe: Safe, localTx: TransactionLocal): TransactionLocal? {
+        var localTx = localTx
+        kotlin.runCatching {
+            rpcClient.getTransactionReceipt(safe.chain, localTx.ethTxHash)
+        }.onSuccess { txReceipt ->
+            localTx = localTx.copy(
+                status = if (txReceipt.status == BigInteger.ONE) TransactionStatus.SUCCESS else TransactionStatus.FAILED
+            )
+            localTxDao.save(localTx)
+        }.onFailure {
+            // fail silently
+        }
+        return localTx
+    }
+}

--- a/data/src/main/java/io/gnosis/data/repositories/TransactionLocalRepository.kt
+++ b/data/src/main/java/io/gnosis/data/repositories/TransactionLocalRepository.kt
@@ -13,17 +13,16 @@ class TransactionLocalRepository(
     private val rpcClient: RpcClient
 ) {
 
-    suspend fun saveLocally(tx: Transaction, txHash: String, safeTxHash: String, safeTxNonce: BigInteger) {
-        // clean up old txs
-        // only latest tx submitted for execution is relevant
-        localTxDao.deleteAll()
+    suspend fun saveLocally(tx: Transaction, txHash: String, safeTxHash: String, safeTxNonce: BigInteger, submittedAt: Long) {
+        localTxDao.clearOldRecords(tx.chainId, tx.to)
         val localTx = TransactionLocal(
             safeAddress = tx.to,
             chainId = tx.chainId,
             safeTxNonce = safeTxNonce,
             safeTxHash = safeTxHash,
             ethTxHash = txHash,
-            status = TransactionStatus.PENDING
+            status = TransactionStatus.PENDING,
+            submittedAt = submittedAt
         )
         localTxDao.save(localTx)
     }
@@ -37,7 +36,7 @@ class TransactionLocalRepository(
     }
 
     suspend fun getLocalTx(safe: Safe, safeTxHash: String): TransactionLocal? =
-        localTxDao.loadyByEthTxHash(safe.chainId, safe.address, safeTxHash)
+        localTxDao.loadyBySafeTxHash(safe.chainId, safe.address, safeTxHash)
 
     suspend fun getLocalTxLatest(safe: Safe): TransactionLocal? =
         localTxDao.loadLatest(safe.chainId, safe.address)


### PR DESCRIPTION
Handles #1987

Changes proposed in this pull request:
- Persist tx data submitted to execution locally
- Get tx receipt and update tx status to pending if it was not yet indexed

@gnosis/mobile-devs
