### PR TITLE
Allow execution of txs with more confirmations than necessary

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsViewModel.kt
@@ -138,7 +138,7 @@ class TransactionDetailsViewModel
     ): Boolean {
         //TODO: Modify this check when we have tx execution on Ledger Nano X
         val ownersThatCanExecute = localOwners.filter { it.type != Owner.Type.LEDGER_NANO_X && executionInfo.signers.contains(AddressInfo(it.address))}
-        return ownersThatCanExecute.isNotEmpty() && executionInfo.confirmations.size == executionInfo.confirmationsRequired
+        return ownersThatCanExecute.isNotEmpty() && executionInfo.confirmations.size >= executionInfo.confirmationsRequired
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)


### PR DESCRIPTION
Handles #

Changes proposed in this pull request:

![Screenshot_20230905-144809](https://github.com/safe-global/safe-android/assets/246473/40e9f369-b08d-4d39-85b1-e6d5c9832331)


before | after 
-------|------
![Screenshot_20230905-144325](https://github.com/safe-global/safe-android/assets/246473/6591b30e-4825-49f8-a0e7-235930277bdb) | ![Screenshot_20230905-144405](https://github.com/safe-global/safe-android/assets/246473/65d07e6c-03c5-44e9-8d41-b67ffaf25a82)

@gnosis/mobile-devs
