### PR TITLE
GH-2036 fixed safeTxHash calculation for the 'swap order' transaction

### DIFF
--- a/data/src/main/java/io/gnosis/data/utils/SafeTxHash.kt
+++ b/data/src/main/java/io/gnosis/data/utils/SafeTxHash.kt
@@ -41,6 +41,9 @@ fun calculateSafeTxHash(
         is TransactionInfo.SettingsChange -> {
             safeAddress
         }
+        is TransactionInfo.SwapOrder -> {
+            safeAddress
+        }
         else -> {
             throw UnsupportedTransactionType(transaction::javaClass.name)
         }


### PR DESCRIPTION
Handles #2036 

Changes proposed in this pull request:
- handle the 'swap order' in the `safeTxHash` calculation
 