### PR TITLE
GH-2044 fixed missing field in the safeTxHash calculation.

### DIFF
--- a/data/src/main/java/io/gnosis/data/utils/SafeTxHash.kt
+++ b/data/src/main/java/io/gnosis/data/utils/SafeTxHash.kt
@@ -56,7 +56,7 @@ fun calculateSafeTxHash(
     val txGasString = executionInfo.safeTxGas.paddedHexString()
     val dataGasString = executionInfo.baseGas.paddedHexString()
     val gasTokenString = executionInfo.gasToken.value.paddedHexString()
-    val refundReceiverString = BigInteger.ZERO.paddedHexString()
+    val refundReceiverString = (executionInfo.refundReceiver?.value?.value ?: BigInteger.ZERO).paddedHexString()
     val nonce = executionInfo.nonce.paddedHexString()
 
     return hash(


### PR DESCRIPTION
Handles #2044

Changes proposed in this pull request:
- Adds 'refundReceiver' to the safeTxHash calculation.
